### PR TITLE
Enable trusted publishing via uv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,6 @@ jobs:
     permissions:
       id-token: write # for Trusted Publishing to pyx
       contents: read
-    env:
-      PYX_API_KEY: ${{ secrets.PYX_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
docs: https://github.com/astral-sh/pyx-auth-action


requires a test publish after merge