### PR TITLE
verify cert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.15.2"
+version = "0.15.3"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.15.2",
+  "version": "0.15.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/kcl_docs.py
+++ b/src/zoo_mcp/kcl_docs.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote, urlparse
 
 import httpx
 
-from zoo_mcp import logger
+from zoo_mcp import ctx, logger
 from zoo_mcp.utils.data_retrieval_utils import (
     ZOO_BASE_URL,
     ZOO_SITEMAP_URL,
@@ -158,7 +158,7 @@ async def _fetch_docs_from_zoo_dev() -> KCLDocs:
 
     logger.info(f"Fetching KCL documentation from {ZOO_BASE_URL}...")
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(timeout=30.0, verify=ctx) as client:
         doc_paths = await _discover_doc_paths(client)
         if not doc_paths:
             return docs

--- a/src/zoo_mcp/kcl_samples.py
+++ b/src/zoo_mcp/kcl_samples.py
@@ -21,7 +21,7 @@ from typing import ClassVar, TypedDict
 
 import httpx
 
-from zoo_mcp import logger
+from zoo_mcp import ctx, logger
 from zoo_mcp.utils.data_retrieval_utils import (
     ZOO_BASE_URL,
     extract_excerpt,
@@ -195,7 +195,7 @@ async def _fetch_index_from_zoo_dev() -> KCLSamples:
 
     logger.info(f"Fetching KCL samples index from {ZOO_BASE_URL}...")
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with httpx.AsyncClient(timeout=30.0, verify=ctx) as client:
         markdown = await fetch_markdown(client, _AQUARIUM_BASE_URL, "/aquarium")
         if markdown is None:
             return samples
@@ -344,7 +344,7 @@ async def get_sample_content(sample_name: str) -> SampleData | None:
     if sample_name in samples.file_index:
         file_contents = samples.file_index[sample_name]
     else:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, verify=ctx) as client:
             file_contents = await _fetch_sample_files(client, sample_name)
 
         if not file_contents:

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.15.2"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
in order for local certs to work with docs search and samples search we need to use the same verify context as was used with the kittycad client