### PR TITLE
Only cache successful fetch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.16.0"
+version = "0.16.1"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/kcl_docs.py
+++ b/src/zoo_mcp/kcl_docs.py
@@ -84,7 +84,9 @@ class KCLDocs:
             cls._init_lock = asyncio.Lock()
         async with cls._init_lock:
             if cls._instance is None:
-                cls._instance = await _fetch_docs_from_zoo_dev()
+                result = await _fetch_docs_from_zoo_dev()
+                if result.docs:
+                    cls._instance = result
 
 
 def _categorize_doc_path(path: str) -> str | None:

--- a/src/zoo_mcp/kcl_samples.py
+++ b/src/zoo_mcp/kcl_samples.py
@@ -127,7 +127,9 @@ class KCLSamples:
             cls._init_lock = asyncio.Lock()
         async with cls._init_lock:
             if cls._instance is None:
-                cls._instance = await _fetch_index_from_zoo_dev()
+                result = await _fetch_index_from_zoo_dev()
+                if result.manifest:
+                    cls._instance = result
 
 
 def _parse_index_markdown(markdown: str) -> dict[str, SampleMetadata]:

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
It's possible that a transient failure can cause an empty list of docs/samples