### PR TITLE
Static binary and cross platform tests

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,109 @@
+name: install-smoke
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - '.github/workflows/install-smoke.yml'
+      - 'scripts/smoke_launch.py'
+  workflow_dispatch:
+
+jobs:
+  build-wheel:
+    name: Build wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-wheel
+          path: dist/*.whl
+
+  install:
+    name: Install (${{ matrix.os }} / py${{ matrix.python-version }} / ${{ matrix.installer }})
+    needs: [ build-wheel ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ '3.11', '3.12', '3.13' ]
+        installer: [ pip, uv ]
+    runs-on: ${{ matrix.os }}
+    env:
+      # Dummy token so the import / launch checks need no secret (KittyCAD
+      # client is constructed at import time). No real API calls are made.
+      ZOO_API_TOKEN: dummy-smoke-token
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        if: matrix.installer == 'uv'
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Download wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: smoke-wheel
+          path: dist
+
+      # --- pip path: install into the setup-python interpreter, as an end user would ---
+      - name: Install with pip
+        if: matrix.installer == 'pip'
+        shell: bash
+        run: python -m pip install dist/*.whl
+
+      - name: Import check (pip)
+        if: matrix.installer == 'pip'
+        shell: bash
+        run: python -c "import zoo_mcp.server"
+
+      - name: Launch smoke (pip)
+        if: matrix.installer == 'pip'
+        shell: bash
+        run: python scripts/smoke_launch.py python -m zoo_mcp
+
+      # --- uv path: install into a fresh uv venv ---
+      - name: Install with uv
+        if: matrix.installer == 'uv'
+        shell: bash
+        run: |
+          uv venv --python ${{ matrix.python-version }}
+          uv pip install dist/*.whl
+
+      - name: Import check (uv)
+        if: matrix.installer == 'uv'
+        shell: bash
+        run: uv run --no-sync python -c "import zoo_mcp.server"
+
+      - name: Launch smoke (uv)
+        if: matrix.installer == 'uv'
+        shell: bash
+        run: uv run --no-sync python scripts/smoke_launch.py python -m zoo_mcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,24 +38,97 @@ jobs:
           name: wheels
           path: dist/*
 
+  build-binaries:
+    name: Build binary (${{ matrix.os_label }}-${{ matrix.arch_label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os_label: linux
+            arch_label: x86_64
+            ext: ""
+          - runner: ubuntu-24.04-arm
+            os_label: linux
+            arch_label: arm64
+            ext: ""
+          - runner: macos-latest
+            os_label: macos
+            arch_label: arm64
+            ext: ""
+          - runner: macos-13
+            os_label: macos
+            arch_label: x86_64
+            ext: ""
+          - runner: windows-latest
+            os_label: windows
+            arch_label: x86_64
+            ext: ".exe"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the project
+        run: uv sync --no-dev
+
+      - name: Build binary
+        shell: bash
+        run: |
+          uv run --with pyinstaller pyinstaller \
+            --onefile --name zoo-mcp \
+            --copy-metadata zoo_mcp \
+            --collect-all mcp --collect-all kcl --collect-all kittycad \
+            --collect-all trimesh --collect-all truststore \
+            pyinstaller_entry.py
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          mv "dist/zoo-mcp${{ matrix.ext }}" \
+            "dist/zoo-mcp-${{ matrix.os_label }}-${{ matrix.arch_label }}${{ matrix.ext }}"
+
+      - name: Smoke test the binary
+        shell: bash
+        run: |
+          python scripts/smoke_launch.py \
+            "./dist/zoo-mcp-${{ matrix.os_label }}-${{ matrix.arch_label }}${{ matrix.ext }}"
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-${{ matrix.os_label }}-${{ matrix.arch_label }}
+          path: dist/zoo-mcp-${{ matrix.os_label }}-${{ matrix.arch_label }}${{ matrix.ext }}
+
   release:
     name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [ build ]
+    needs: [ build, build-binaries ]
     steps:
-      - name: Download wheels
+      - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
-          name: wheels
           path: dist
 
       - name: Create a Release
         uses: softprops/action-gh-release@v3
         with:
-          files: ./dist/*
+          files: |
+            dist/wheels/*
+            dist/binary-*/*
 
   publish-pyx:
     name: Publish to pyx
@@ -73,6 +146,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
+          name: wheels
           path: dist
 
       - name: Install uv
@@ -111,6 +185,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
+          name: wheels
           path: dist
 
       - name: Install uv

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An [MCP server](https://modelcontextprotocol.io/docs/getting-started/intro) hous
 
 4. Install the package from GitHub
     ```bash
-    uv pip install git+ssh://git@github.com/KittyCAD/zoo-mcp.git
+    uv pip install git+ssh://git@github.com/KittyCAD/mcp.git
     ```
 
 ## Running the Server

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ The server can also be run with the [mcp package](https://github.com/modelcontex
 uv run mcp run src/zoo_mcp/server.py
 ```
 
+### Prebuilt binaries
+
+Each [GitHub release](https://github.com/KittyCAD/mcp/releases) also attaches standalone executables (built with PyInstaller) for Linux (`x86_64`, `arm64`), macOS (`arm64`, `x86_64`), and Windows (`x86_64`) — no Python toolchain required. Download the binary for your platform, set `ZOO_API_TOKEN`, and run it directly, e.g.:
+```bash
+ZOO_API_TOKEN="your_api_key_here" ./zoo-mcp-linux-x86_64
+```
+> The binaries are not code-signed, so macOS Gatekeeper and Windows SmartScreen may warn on first run.
+
 ## Integrations
 
 The server can be used as is by [running the server](#running-the-server) or importing directly into your python code.

--- a/pyinstaller_entry.py
+++ b/pyinstaller_entry.py
@@ -1,0 +1,10 @@
+"""PyInstaller entry point for the standalone ``zoo-mcp`` binary.
+
+Mirrors the ``zoo-mcp`` console script (``zoo_mcp.server:main``) so the
+frozen executable behaves identically to ``uvx zoo-mcp`` / ``python -m zoo_mcp``.
+"""
+
+from zoo_mcp.server import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pillow<13.0",
     "trimesh<5.0",
     "truststore<1.0",
+    "typing-extensions>=4.12",
     "zoo-kcl>=0.3.161",
 ]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.16.2"
+version = "0.16.3"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/scripts/smoke_launch.py
+++ b/scripts/smoke_launch.py
@@ -1,0 +1,41 @@
+"""Launch an MCP server command, feed EOF on stdin, and assert it starts up.
+
+Shared by the release binary smoke check and the install-smoke matrix. The
+server is a blocking stdio loop with no ``--help``, so we close stdin (EOF) and
+bound it with a timeout, then assert the startup banner reached stderr.
+
+Usage:
+    python scripts/smoke_launch.py ./dist/zoo-mcp-linux-x86_64
+    python scripts/smoke_launch.py python -m zoo_mcp
+"""
+
+import os
+import subprocess
+import sys
+
+cmd = sys.argv[1:]
+if not cmd:
+    sys.exit("smoke_launch: expected a command to run")
+
+# Run "python ..." with the interpreter executing this script (e.g. the venv's
+# Python) rather than whatever "python" resolves to first on PATH.
+if cmd[0] == "python":
+    cmd[0] = sys.executable
+
+# A token is required to construct the KittyCAD client at import time; use a
+# dummy so the smoke check needs no secret (and runs on fork PRs).
+env = {
+    **os.environ,
+    "ZOO_API_TOKEN": os.environ.get("ZOO_API_TOKEN", "dummy-smoke-token"),
+}
+
+try:
+    proc = subprocess.run(
+        cmd, stdin=subprocess.DEVNULL, capture_output=True, timeout=60, env=env
+    )
+    err = proc.stderr.decode(errors="replace")
+except subprocess.TimeoutExpired as exc:
+    err = (exc.stderr or b"").decode(errors="replace")
+
+sys.stderr.write(err)
+sys.exit(0 if "Starting MCP server" in err else 1)

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.16.2",
+  "version": "0.16.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/kcl_samples.py
+++ b/src/zoo_mcp/kcl_samples.py
@@ -17,9 +17,14 @@ contents on demand.
 import asyncio
 import re
 from dataclasses import dataclass, field
-from typing import ClassVar, TypedDict
+from typing import ClassVar
 
 import httpx
+
+# pydantic requires typing_extensions.TypedDict (not typing.TypedDict) to build
+# schemas on Python < 3.12; the MCP tools expose these TypedDicts, so import the
+# backport for consistent behavior across 3.11-3.13.
+from typing_extensions import TypedDict
 
 from zoo_mcp import ctx, logger
 from zoo_mcp.utils.data_retrieval_utils import (

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -1169,6 +1169,7 @@ dependencies = [
     { name = "pillow" },
     { name = "trimesh" },
     { name = "truststore" },
+    { name = "typing-extensions" },
     { name = "zoo-kcl" },
 ]
 
@@ -1191,6 +1192,7 @@ requires-dist = [
     { name = "pillow", specifier = "<13.0" },
     { name = "trimesh", specifier = "<5.0" },
     { name = "truststore", specifier = "<1.0" },
+    { name = "typing-extensions", specifier = ">=4.12" },
     { name = "zoo-kcl", specifier = ">=0.3.161" },
 ]
 


### PR DESCRIPTION
## Summary

Two release/CI improvements:

1. **Standalone binaries at release.** Alongside the wheel, releases now attach self-contained executables (PyInstaller `--onefile`) for Linux (x86_64, arm64), macOS (arm64, x86_64), and Windows (x86_64) — run `zoo-mcp` with no Python toolchain.
2. **Cross-platform install smoke test.** A user hit a Windows install failure that our ubuntu-only, single-Python CI never exercised. New `install-smoke` workflow builds the wheel and installs it across {Linux, macOS, Windows} × {3.11, 3.12, 3.13} × {pip, uv} (18 cells), verifying it imports and launches.

## Changes

- `pyinstaller_entry.py` — PyInstaller entry mirroring the `zoo-mcp` console script.
- `scripts/smoke_launch.py` — shared helper that launches the (blocking stdio) server, feeds EOF with a timeout, and asserts the startup banner.
- `release.yml` — new `build-binaries` matrix job; `release` job attaches binaries alongside wheels. **`publish-pyx`/`publish-pypi` now download `name: wheels` only, so binaries are never pushed to the indexes.**
- `install-smoke.yml` — new OS × Python × installer matrix (`fail-fast: false`, dummy `ZOO_API_TOKEN`, so it runs on fork PRs without secrets).
- `kcl_samples.py` / `pyproject.toml` — import `TypedDict` from `typing_extensions` (Python 3.11 fix) and declare `typing-extensions` as a direct dependency.
- `README.md` — documents the prebuilt binaries and the unsigned-binary caveat.

## Notes

- macOS/Windows binaries are **unsigned** (Gatekeeper/SmartScreen may warn).
- The install-smoke matrix is intentionally `fail-fast: false` so the exact failing OS/Python/installer cell is obvious.
