### PR TITLE
Use GitHub-hosted macos-15 runners (macos-13 retired)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-15, windows-latest ]
+        os: [ ubuntu-latest, macos-26, windows-latest ]
         python-version: [ '3.11', '3.12', '3.13' ]
         installer: [ pip, uv ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-15, windows-latest ]
         python-version: [ '3.11', '3.12', '3.13' ]
         installer: [ pip, uv ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,11 @@ jobs:
             os_label: linux
             arch_label: arm64
             ext: ""
-          - runner: macos-latest
+          - runner: macos-15
             os_label: macos
             arch_label: arm64
             ext: ""
-          - runner: macos-13
+          - runner: macos-15-intel
             os_label: macos
             arch_label: x86_64
             ext: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
             os_label: linux
             arch_label: arm64
             ext: ""
-          - runner: macos-15
+          - runner: macos-26
             os_label: macos
             arch_label: arm64
             ext: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.16.3"
+version = "0.16.4"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.16.3",
+  "version": "0.16.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Follow-up to #178. The macOS runners used by the new binary build and install-smoke matrix needed updating:

- **`macos-13` (Intel) was retired in Dec 2025** — jobs using it now fail, so the binary build's x86_64 mac job would break.
- `macos-latest` is mid-migration (the June 2026 image migration), so pinning explicit versions avoids surprises.

## Changes

- `release.yml` binary build: `macos-latest` → **`macos-26`** (arm64, GA since Feb 2026) and `macos-13` → **`macos-15-intel`** (x86_64), keeping both mac architectures in the release.
- `install-smoke.yml`: `macos-latest` → **`macos-26`**.
