### PR TITLE
Expose KCL snapshot edge visibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.18.1"
+version = "0.18.2"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",
@@ -14,7 +14,7 @@ dependencies = [
     "trimesh<5.0",
     "truststore<1.0",
     "typing-extensions>=4.12",
-    "zoo-kcl>=0.3.170",
+    "zoo-kcl>=0.3.173",
 ]
 authors = [
     { name = "Ryan Barton", email = "ryan@zoo.dev" },

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.18.1",
+  "version": "0.18.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -595,7 +595,7 @@ async def multiview_snapshot_of_kcl(
     kcl_path: str | None = None,
     zoom: bool = True,
     output_path: str | None = None,
-    highlight_edges: bool | None = None,
+    highlight_edges: bool = False,
 ) -> ImageContent | str:
     """Save a multiview snapshot of KCL code. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -610,7 +610,7 @@ async def multiview_snapshot_of_kcl(
         kcl_path (str | None): The path to a KCL file to export to a CAD file. The path should point to a .kcl file or a directory containing a main.kcl file.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
-        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
+        highlight_edges (bool): Whether rendered edges should be highlighted. Default is False.
 
     Returns:
         ImageContent | str: The multiview snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.
@@ -675,7 +675,7 @@ async def multi_isometric_snapshot_of_kcl(
     kcl_path: str | None = None,
     zoom: bool = True,
     output_path: str | None = None,
-    highlight_edges: bool | None = None,
+    highlight_edges: bool = False,
 ) -> ImageContent | str:
     """Save a multi-isometric snapshot of KCL code showing 4 isometric views. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -690,7 +690,7 @@ async def multi_isometric_snapshot_of_kcl(
         kcl_path (str | None): The path to a KCL file to export to a CAD file. The path should point to a .kcl file or a directory containing a main.kcl file.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
-        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
+        highlight_edges (bool): Whether rendered edges should be highlighted. Default is False.
 
     Returns:
         ImageContent | str: The multi-isometric snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.
@@ -784,7 +784,7 @@ async def snapshot_of_kcl(
     camera_view: dict[str, list[float]] | str = "isometric",
     zoom: bool = True,
     output_path: str | None = None,
-    highlight_edges: bool | None = None,
+    highlight_edges: bool = False,
 ) -> ImageContent | str:
     """Save a snapshot of a model represented by KCL. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -800,7 +800,7 @@ async def snapshot_of_kcl(
                For example camera = {"up": [0, 0, 1], "vantage": [0, -1, 0], "center": [0, 0, 0]} would set the camera to be looking at the origin from the front side (-y direction).
         zoom (bool): Whether to zoom-to-fit the model before the snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
-        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
+        highlight_edges (bool): Whether rendered edges should be highlighted. Default is False.
 
     Returns:
         ImageContent | str: The snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -595,6 +595,7 @@ async def multiview_snapshot_of_kcl(
     kcl_path: str | None = None,
     zoom: bool = True,
     output_path: str | None = None,
+    highlight_edges: bool | None = None,
 ) -> ImageContent | str:
     """Save a multiview snapshot of KCL code. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -609,6 +610,7 @@ async def multiview_snapshot_of_kcl(
         kcl_path (str | None): The path to a KCL file to export to a CAD file. The path should point to a .kcl file or a directory containing a main.kcl file.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         ImageContent | str: The multiview snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.
@@ -621,6 +623,7 @@ async def multiview_snapshot_of_kcl(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             zoom=zoom,
+            highlight_edges=highlight_edges,
         )
         if output_path is not None:
             return save_image_bytes_to_disk(image, output_path)
@@ -672,6 +675,7 @@ async def multi_isometric_snapshot_of_kcl(
     kcl_path: str | None = None,
     zoom: bool = True,
     output_path: str | None = None,
+    highlight_edges: bool | None = None,
 ) -> ImageContent | str:
     """Save a multi-isometric snapshot of KCL code showing 4 isometric views. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -686,6 +690,7 @@ async def multi_isometric_snapshot_of_kcl(
         kcl_path (str | None): The path to a KCL file to export to a CAD file. The path should point to a .kcl file or a directory containing a main.kcl file.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         ImageContent | str: The multi-isometric snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.
@@ -698,6 +703,7 @@ async def multi_isometric_snapshot_of_kcl(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             zoom=zoom,
+            highlight_edges=highlight_edges,
         )
         if output_path is not None:
             return save_image_bytes_to_disk(image, output_path)
@@ -778,6 +784,7 @@ async def snapshot_of_kcl(
     camera_view: dict[str, list[float]] | str = "isometric",
     zoom: bool = True,
     output_path: str | None = None,
+    highlight_edges: bool | None = None,
 ) -> ImageContent | str:
     """Save a snapshot of a model represented by KCL. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -793,6 +800,7 @@ async def snapshot_of_kcl(
                For example camera = {"up": [0, 0, 1], "vantage": [0, -1, 0], "center": [0, 0, 0]} would set the camera to be looking at the origin from the front side (-y direction).
         zoom (bool): Whether to zoom-to-fit the model before the snapshot. Default is True.
         output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         ImageContent | str: The snapshot as an inline image when output_path is omitted; otherwise the absolute path to the saved file. Returns an error message string if the operation fails.
@@ -831,6 +839,7 @@ async def snapshot_of_kcl(
             kcl_path=kcl_path,
             camera=camera,
             zoom=zoom,
+            highlight_edges=highlight_edges,
         )
         if output_path is not None:
             return save_image_bytes_to_disk(image, output_path)

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -244,6 +244,22 @@ async def _execute_with_retries(
             raise
 
 
+def _snapshot_view_kwargs(
+    snapshot_options: list[kcl.SnapshotOptions],
+    *,
+    zoom: bool,
+    highlight_edges: bool | None,
+) -> dict[str, object]:
+    """Build snapshot kwargs, omitting optional edge visibility when unset."""
+    kwargs: dict[str, object] = {
+        "snapshot_options": snapshot_options,
+        "zoom": zoom,
+    }
+    if highlight_edges is not None:
+        kwargs["highlight_edges"] = highlight_edges
+    return kwargs
+
+
 # Issue severities surfaced from an execution outcome, in descending order of
 # severity. Each entry maps a ``kcl.CompilationIssue`` predicate to the label
 # used when rendering that issue's report. ``is_fatal`` is checked before
@@ -1701,6 +1717,7 @@ async def zoo_multi_isometric_snapshot_of_kcl(
     padding: float = 0.1,
     max_image_dimension: int = 512,
     zoom: bool = True,
+    highlight_edges: bool | None = None,
 ) -> bytes:
     """Execute the KCL code and save a multi-isometric snapshot showing 4 isometric views. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -1710,6 +1727,7 @@ async def zoo_multi_isometric_snapshot_of_kcl(
         padding (float): The padding to apply to the snapshot. Default is 0.1.
         max_image_dimension (int): The maximum width or height of the returned image in pixels. Default is 512.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         bytes or None: The JPEG image contents if successful
@@ -1743,8 +1761,11 @@ async def zoo_multi_isometric_snapshot_of_kcl(
                         kcl.execute_code_and_snapshot_views,
                         kcl_code,
                         kcl.ImageFormat.Jpeg,
-                        snapshot_options=views,
-                        zoom=zoom,
+                        **_snapshot_view_kwargs(
+                            views,
+                            zoom=zoom,
+                            highlight_edges=highlight_edges,
+                        ),
                     ),
                 ),
             )
@@ -1761,8 +1782,11 @@ async def zoo_multi_isometric_snapshot_of_kcl(
                         kcl.execute_and_snapshot_views,
                         str(kcl_path_resolved),
                         kcl.ImageFormat.Jpeg,
-                        snapshot_options=views,
-                        zoom=zoom,
+                        **_snapshot_view_kwargs(
+                            views,
+                            zoom=zoom,
+                            highlight_edges=highlight_edges,
+                        ),
                     ),
                 ),
             )
@@ -1782,6 +1806,7 @@ async def zoo_multiview_snapshot_of_kcl(
     padding: float = 0.1,
     max_image_dimension: int = 512,
     zoom: bool = True,
+    highlight_edges: bool | None = None,
 ) -> bytes:
     """Execute the KCL code and save a multiview snapshot of the resulting CAD model. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -1791,6 +1816,7 @@ async def zoo_multiview_snapshot_of_kcl(
         padding (float): The padding to apply to the snapshot. Default is 0.1.
         max_image_dimension (int): The maximum width or height of the returned image in pixels. Default is 512.
         zoom (bool): Whether to zoom-to-fit the model before each snapshot. Default is True.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         bytes or None: The JPEG image contents if successful
@@ -1837,8 +1863,11 @@ async def zoo_multiview_snapshot_of_kcl(
                         kcl.execute_code_and_snapshot_views,
                         kcl_code,
                         kcl.ImageFormat.Jpeg,
-                        snapshot_options=views,
-                        zoom=zoom,
+                        **_snapshot_view_kwargs(
+                            views,
+                            zoom=zoom,
+                            highlight_edges=highlight_edges,
+                        ),
                     ),
                 ),
             )
@@ -1855,8 +1884,11 @@ async def zoo_multiview_snapshot_of_kcl(
                         kcl.execute_and_snapshot_views,
                         str(kcl_path_resolved),
                         kcl.ImageFormat.Jpeg,
-                        snapshot_options=views,
-                        zoom=zoom,
+                        **_snapshot_view_kwargs(
+                            views,
+                            zoom=zoom,
+                            highlight_edges=highlight_edges,
+                        ),
                     ),
                 ),
             )
@@ -2017,6 +2049,7 @@ async def zoo_snapshot_of_kcl(
     padding: float = 0.1,
     max_image_dimension: int = 512,
     zoom: bool = True,
+    highlight_edges: bool | None = None,
 ) -> bytes:
     """Execute the KCL code and save a single view snapshot of the resulting CAD model. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -2027,6 +2060,7 @@ async def zoo_snapshot_of_kcl(
         padding (float): The padding to apply to the snapshot. Default is 0.1.
         max_image_dimension (int): The maximum width or height of the returned image in pixels. Default is 512.
         zoom (bool): Whether to zoom-to-fit the model before the snapshot. Default is True.
+        highlight_edges (bool | None): Whether rendered edges should be highlighted. If None, the zoo-kcl default is used.
 
     Returns:
         bytes or None: The JPEG image contents if successful
@@ -2048,8 +2082,11 @@ async def zoo_snapshot_of_kcl(
                     kcl.execute_code_and_snapshot_views,
                     kcl_code,
                     kcl.ImageFormat.Jpeg,
-                    snapshot_options=[view],
-                    zoom=zoom,
+                    **_snapshot_view_kwargs(
+                        [view],
+                        zoom=zoom,
+                        highlight_edges=highlight_edges,
+                    ),
                 ),
             ),
         )
@@ -2066,8 +2103,11 @@ async def zoo_snapshot_of_kcl(
                     kcl.execute_and_snapshot_views,
                     str(kcl_path_resolved),
                     kcl.ImageFormat.Jpeg,
-                    snapshot_options=[view],
-                    zoom=zoom,
+                    **_snapshot_view_kwargs(
+                        [view],
+                        zoom=zoom,
+                        highlight_edges=highlight_edges,
+                    ),
                 ),
             ),
         )

--- a/tests/test_snapshot_edge_visibility.py
+++ b/tests/test_snapshot_edge_visibility.py
@@ -1,0 +1,119 @@
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from zoo_mcp import server, zoo_tools
+
+SnapshotFunction = Callable[..., Awaitable[bytes]]
+ServerSnapshotFunction = Callable[..., Awaitable[object]]
+
+KCL_SNAPSHOT_FUNCTIONS: tuple[SnapshotFunction, ...] = (
+    zoo_tools.zoo_snapshot_of_kcl,
+    zoo_tools.zoo_multiview_snapshot_of_kcl,
+    zoo_tools.zoo_multi_isometric_snapshot_of_kcl,
+)
+
+SERVER_SNAPSHOT_FUNCTIONS: tuple[tuple[ServerSnapshotFunction, str], ...] = (
+    (server.snapshot_of_kcl, "zoo_snapshot_of_kcl"),
+    (server.multiview_snapshot_of_kcl, "zoo_multiview_snapshot_of_kcl"),
+    (
+        server.multi_isometric_snapshot_of_kcl,
+        "zoo_multi_isometric_snapshot_of_kcl",
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "snapshot_function",
+    KCL_SNAPSHOT_FUNCTIONS,
+    ids=lambda function: function.__name__,
+)
+@pytest.mark.parametrize("use_code", [True, False], ids=["code", "path"])
+@pytest.mark.parametrize("highlight_edges", [False, True], ids=["hidden", "shown"])
+async def test_kcl_snapshot_forwards_highlight_edges(
+    snapshot_function: SnapshotFunction,
+    use_code: bool,
+    highlight_edges: bool,
+    cube_kcl: str,
+):
+    code_snapshot = AsyncMock(return_value=[b"view"] * 4)
+    path_snapshot = AsyncMock(return_value=[b"view"] * 4)
+
+    with (
+        patch.object(
+            zoo_tools.kcl,
+            "execute_code_and_snapshot_views",
+            new=code_snapshot,
+        ),
+        patch.object(
+            zoo_tools.kcl,
+            "execute_and_snapshot_views",
+            new=path_snapshot,
+        ),
+        patch.object(zoo_tools, "create_image_collage", return_value=b"collage"),
+        patch.object(zoo_tools, "resize_image", return_value=b"snapshot"),
+    ):
+        result = await snapshot_function(
+            kcl_code="cube()" if use_code else None,
+            kcl_path=None if use_code else cube_kcl,
+            highlight_edges=highlight_edges,
+        )
+
+    assert result == b"snapshot"
+    selected_snapshot = code_snapshot if use_code else path_snapshot
+    unused_snapshot = path_snapshot if use_code else code_snapshot
+    selected_snapshot.assert_awaited_once()
+    unused_snapshot.assert_not_awaited()
+    await_args = selected_snapshot.await_args
+    assert await_args is not None
+    assert await_args.kwargs["highlight_edges"] is highlight_edges
+
+
+@pytest.mark.asyncio
+async def test_kcl_snapshot_omits_highlight_edges_by_default(cube_kcl: str):
+    path_snapshot = AsyncMock(return_value=[b"view"])
+
+    with (
+        patch.object(
+            zoo_tools.kcl,
+            "execute_and_snapshot_views",
+            new=path_snapshot,
+        ),
+        patch.object(zoo_tools, "resize_image", return_value=b"snapshot"),
+    ):
+        await zoo_tools.zoo_snapshot_of_kcl(kcl_code=None, kcl_path=cube_kcl)
+
+    path_snapshot.assert_awaited_once()
+    await_args = path_snapshot.await_args
+    assert await_args is not None
+    assert "highlight_edges" not in await_args.kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot_function", "implementation_name"),
+    SERVER_SNAPSHOT_FUNCTIONS,
+    ids=lambda value: value.__name__ if callable(value) else value,
+)
+async def test_server_snapshot_tool_forwards_highlight_edges(
+    snapshot_function: ServerSnapshotFunction,
+    implementation_name: str,
+):
+    implementation = AsyncMock(return_value=b"snapshot")
+
+    with (
+        patch.object(server, implementation_name, new=implementation),
+        patch.object(server, "encode_image", return_value="encoded"),
+    ):
+        result = await snapshot_function(
+            kcl_code="cube()",
+            highlight_edges=False,
+        )
+
+    assert result == "encoded"
+    implementation.assert_awaited_once()
+    await_args = implementation.await_args
+    assert await_args is not None
+    assert await_args.kwargs["highlight_edges"] is False

--- a/tests/test_snapshot_edge_visibility.py
+++ b/tests/test_snapshot_edge_visibility.py
@@ -97,7 +97,7 @@ async def test_kcl_snapshot_omits_highlight_edges_by_default(cube_kcl: str):
     SERVER_SNAPSHOT_FUNCTIONS,
     ids=lambda value: value.__name__ if callable(value) else value,
 )
-async def test_server_snapshot_tool_forwards_highlight_edges(
+async def test_server_snapshot_tool_disables_highlight_edges_by_default(
     snapshot_function: ServerSnapshotFunction,
     implementation_name: str,
 ):
@@ -107,13 +107,35 @@ async def test_server_snapshot_tool_forwards_highlight_edges(
         patch.object(server, implementation_name, new=implementation),
         patch.object(server, "encode_image", return_value="encoded"),
     ):
-        result = await snapshot_function(
-            kcl_code="cube()",
-            highlight_edges=False,
-        )
+        result = await snapshot_function(kcl_code="cube()")
 
     assert result == "encoded"
     implementation.assert_awaited_once()
     await_args = implementation.await_args
     assert await_args is not None
     assert await_args.kwargs["highlight_edges"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("snapshot_function", "implementation_name"),
+    SERVER_SNAPSHOT_FUNCTIONS,
+    ids=lambda value: value.__name__ if callable(value) else value,
+)
+async def test_server_snapshot_tool_allows_highlight_edges_override(
+    snapshot_function: ServerSnapshotFunction,
+    implementation_name: str,
+):
+    implementation = AsyncMock(return_value=b"snapshot")
+
+    with (
+        patch.object(server, implementation_name, new=implementation),
+        patch.object(server, "encode_image", return_value="encoded"),
+    ):
+        result = await snapshot_function(kcl_code="cube()", highlight_edges=True)
+
+    assert result == "encoded"
+    implementation.assert_awaited_once()
+    await_args = implementation.await_args
+    assert await_args is not None
+    assert await_args.kwargs["highlight_edges"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -1123,25 +1123,25 @@ wheels = [
 
 [[package]]
 name = "zoo-kcl"
-version = "0.3.170"
+version = "0.3.173"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/8f/7e40a7822e53dd15ad0939e87c8b88f209be5b0dc2cae71147a40340791b/zoo_kcl-0.3.170.tar.gz", hash = "sha256:cb22457204d189a46947b130a2db19ddbb3058bb0b3e83d289bbd71a9540188f", size = 1019017, upload-time = "2026-07-22T16:56:58.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/f0/c01306eaebd4ae0f25a824a0396e34a924750100b641459d22026078e80c/zoo_kcl-0.3.173.tar.gz", hash = "sha256:11c064c018ff7d040356e21a877d71664071e09273c6eb096eb7a049b0920595", size = 1037234, upload-time = "2026-07-29T21:22:07.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/d2/6cd465690a7361a5b54d189afbb70f62ecaadf36496893875a1887ef939c/zoo_kcl-0.3.170-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:17dff17dd53e1c21df263ac437ad56185a1714cadc573c3b17d81020cf36b1fe", size = 7408501, upload-time = "2026-07-22T16:56:52.121Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/56/96049b490764a4f04d2d89dc1d289a0d77c644dc7d3127eae135b8956a69/zoo_kcl-0.3.170-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd9ca30644f2ff03784bb68d73513e7bfc1e43d9b84cd18f1c1bcf3e11ed22f3", size = 8657271, upload-time = "2026-07-22T16:56:37.768Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/4d/8a04b62d2ab74547622c39269a0d88e5341469479b5e8d4925815e285c19/zoo_kcl-0.3.170-cp311-cp311-win_amd64.whl", hash = "sha256:f5d76ef4c6bafda9695a10597efde9b02774756eb811ce0f688708740ace14fd", size = 8520146, upload-time = "2026-07-22T16:56:59.235Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/19/56ae92dafde8c9427d2b876f20d93e34cd1771bd2340864e86aa7ace947b/zoo_kcl-0.3.170-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cbe5f1bf220e3574cce053a0085fd489d4806af5e6c0aaf9313a65e4c1b36606", size = 7397608, upload-time = "2026-07-22T16:56:53.644Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/48/eb65d9bbb32197f1302732d9a9ef80db9c741458e851159e9828138aef87/zoo_kcl-0.3.170-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1273e0b9f73123ef4c2a1de2ff4aeb045a7b71fee63a6de2f8023857435326b", size = 8651057, upload-time = "2026-07-22T16:56:39.731Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/e9/e1f87e026c667566f7c412b68a45f0b89be2fe8f5d38eb3b36c6d5577ece/zoo_kcl-0.3.170-cp312-cp312-win_amd64.whl", hash = "sha256:8c6ec1a089134869aa0287c86068de4e8e58c122e4e741d38872fa278dbfc491", size = 8518362, upload-time = "2026-07-22T16:57:00.974Z" },
-    { url = "https://files.pythonhosted.org/packages/07/5d/f37ecd7eb4ad2c9ca4d2db07840aa9ffa47f5d2cbd108aa5e1edd4668cf1/zoo_kcl-0.3.170-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5acf39a9ff1dfab44571583a2edd7be3a0a9b6e8d94ae26bf94e458ecb37552", size = 7397078, upload-time = "2026-07-22T16:56:55.131Z" },
-    { url = "https://files.pythonhosted.org/packages/09/c8/85429aa37aea4d8ed5ca7ebf57fa3ba295c3d2acaa249dd9831921980c29/zoo_kcl-0.3.170-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13152d1fe62b09bef0be0c7d96893ca6dfbc6ac7d93735692dcbda09eeb8bae4", size = 8650278, upload-time = "2026-07-22T16:56:41.463Z" },
-    { url = "https://files.pythonhosted.org/packages/89/30/48f1f487f185f86a3a567b7b37f0eab17d96df6338e7bda5dc38bc3acdd1/zoo_kcl-0.3.170-cp313-cp313-win_amd64.whl", hash = "sha256:ca38da920c41d971ee6fa2efdce06a57fe09898852d01e10529aaedf75c13f9e", size = 8518296, upload-time = "2026-07-22T16:57:02.565Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/4a/799326d69a6464efcb7a5ce274a80bcbea0a9980601a54fd8254a076a12a/zoo_kcl-0.3.170-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe5a6d5e952a56fd9f6dab9e9394fd6d4104416c9c6c8cc58127072b252d96ce", size = 8655396, upload-time = "2026-07-22T16:56:50.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/93/15945e8255fa3d8f728d5ba37baa3166a6f2066a7940cabee9bf882a0a04/zoo_kcl-0.3.173-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ad6025eecae24b3cf3f0ce7da3cab6b8e2a68d67b9a519b65d997b5d87a7a4b", size = 7520613, upload-time = "2026-07-29T21:22:01.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c8/c4e355d5142b255c8c846bf0b59b49210b0f0f3dce8dddfebbc9017ddff2/zoo_kcl-0.3.173-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf937ead13e0bff7c034f99034106252acdb019abec83a0b65a6f4b5b33ba835", size = 8776821, upload-time = "2026-07-29T21:21:49.637Z" },
+    { url = "https://files.pythonhosted.org/packages/00/81/6714171b3ac4638aa0292f8527d88fb5ceacf2a85a5d7877fafeaabbd727/zoo_kcl-0.3.173-cp311-cp311-win_amd64.whl", hash = "sha256:7730e150531e717a7d97bde9dd0c61a929a2b653c87ade18fbc86c32479529c0", size = 8622457, upload-time = "2026-07-29T21:22:09.029Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/41/ddf2078b33df32afc01d1d365ce928c514b0e43eae4fe9699b3aabff29df/zoo_kcl-0.3.173-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9ca1d83d99b30ebfa6854929d5d6a7860ba0e0365fb099ea594287b4a1e5fbca", size = 7508633, upload-time = "2026-07-29T21:22:03.486Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/923df6110df729f5f849620d6847648eacf007dead2d9fc2f0f1c513a856/zoo_kcl-0.3.173-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a3bc46dfad58fdb1d7e3e6dc090391daebbb5861dce261a7bcfaf867f730a31", size = 8773321, upload-time = "2026-07-29T21:21:51.436Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/aa/29e22b425f56799f901e0ef273e37c359b4fb7250f54e7a78c0b32f27ed8/zoo_kcl-0.3.173-cp312-cp312-win_amd64.whl", hash = "sha256:430ae993e6aa1c79e29fef0331fd35c251bda7c4420f6f360790f70c6d31fee1", size = 8628044, upload-time = "2026-07-29T21:22:10.804Z" },
+    { url = "https://files.pythonhosted.org/packages/19/97/d3ad511846c9a0cc7482a8eca68ed1a6273722736549eefee0a79dc8653b/zoo_kcl-0.3.173-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11165f3cd6ae6929a54c18956958b2a804616420caabb8571fa6a892b2bceea0", size = 7508392, upload-time = "2026-07-29T21:22:04.971Z" },
+    { url = "https://files.pythonhosted.org/packages/65/fa/96d3e1be1fa6f866eb097273190416f0f41d37f4d3a245bac274f06d5278/zoo_kcl-0.3.173-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1878045cb65a6997b1420d31c7a3e0a0efb19b10577f11d679bfff1e22167c7", size = 8772111, upload-time = "2026-07-29T21:21:53.662Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/da03809447ebe18654aca809bd3681377c88441cb99672b7465b7f871200/zoo_kcl-0.3.173-cp313-cp313-win_amd64.whl", hash = "sha256:bfa8fa5cb1608d34a8ccb3690071517f3747771d7ee848f0fc5ab03f0e8c2870", size = 8627486, upload-time = "2026-07-29T21:22:12.436Z" },
+    { url = "https://files.pythonhosted.org/packages/03/eb/ff262489a3f807b066b41bc1e7bf2ca9e56ec8fe3b6956d44f5c43345eed/zoo_kcl-0.3.173-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1da2b63b3282815c8c2875f3f1810909b82ffa2b144360b3872ee78f03280e21", size = 8782735, upload-time = "2026-07-29T21:21:59.909Z" },
 ]
 
 [[package]]
 name = "zoo-mcp"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1174,7 +1174,7 @@ requires-dist = [
     { name = "trimesh", specifier = "<5.0" },
     { name = "truststore", specifier = "<1.0" },
     { name = "typing-extensions", specifier = ">=4.12" },
-    { name = "zoo-kcl", specifier = ">=0.3.170" },
+    { name = "zoo-kcl", specifier = ">=0.3.173" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- add an optional `highlight_edges` argument to the single-view, multiview, and multi-isometric KCL snapshot helpers
- expose the same option through the three corresponding MCP tools
- forward explicit `True` and `False` values for both KCL code and path execution
- omit the keyword when unset, preserving current behavior for existing callers
- require the released `zoo-kcl>=0.3.173` support and prepare `zoo-mcp 0.18.2`
