### PR TITLE
Add zoo_face_info & exec_kcl_project tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ from zoo_mcp.server import mcp
 mcp.run()
 ```
 
-Individual tools can be used in your own python code as well
+Individual tools can be used in your own python code as well. At Zoo we use
+zoo-mcp like this with ZooKeeper to save on resources. Instead of spinning up
+one MCP server per agent, each agent in a sense "embeds" the server in their own
+runtime. It has the additional benefit of preventing shared state.
 
 ```python
 from mcp.server.fastmcp import FastMCP
@@ -107,6 +110,20 @@ You can also use the helper script included in this repo:
 ./codex-zoo.sh
 ```
 The script prompts for a request, runs Codex with the Zoo MCP server, and saves a JSONL transcript (including token usage) to `codex-run-<timestamp>.jsonl`.
+
+## Architecture
+
+Tools are defined in `src/zoo_mcp/*.py`, where they are then imported into
+`src/zoo_mcp/server.py` and tied to actual `@mcp.tool()` decorated functions.
+
+`src/zoo_mcp/zoo_tools.py` acts as a large toolset to interact with Zoo's KCL and
+engine facilities. This source file houses other utilities like `parse_unit` or
+`normalize_ext` (normalizing file extensions).
+
+For example, running KCL and taking a snapshot is defined in that source file.
+
+Right now the MCP is structured such that one engine connection is used per
+tool call. MCP's stateless nature is what more or less influenced this.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.18.3"
+version = "0.19.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "trimesh<5.0",
     "truststore<1.0",
     "typing-extensions>=4.12",
-    "zoo-kcl>=0.3.174",
+    "zoo-kcl>=0.3.175",
 ]
 authors = [
     { name = "Ryan Barton", email = "ryan@zoo.dev" },

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.18.3",
+  "version": "0.19.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.18.3",
+      "version": "0.19.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -427,6 +427,7 @@ async def exec_kcl_project(
 
     Returns:
         dict | str: The artifact graph produced by execution, or an error message.
+                    Contains UUID mappings to source code and somewhat structured understanding of the model.
     """
     logger.info("exec_kcl_project tool called")
 

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -38,6 +38,7 @@ from zoo_mcp.zoo_tools import (
     zoo_calculate_surface_area,
     zoo_calculate_volume,
     zoo_convert_cad_file,
+    zoo_exec_kcl_project,
     zoo_execute_kcl,
     zoo_export_kcl,
     zoo_face_info,
@@ -411,6 +412,28 @@ async def execute_kcl(
         return await zoo_execute_kcl(kcl_code=kcl_code, kcl_path=kcl_path)
     except Exception as e:
         return False, f"Failed to execute KCL code: {e}"
+
+
+@mcp.tool()
+async def exec_kcl_project(
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Run a KCL project on the server side and return its artifact graph.
+
+    Args:
+        kcl_code (str | None): KCL code to run as a single-file project.
+        kcl_path (str | None): A .kcl file or project directory containing main.kcl.
+
+    Returns:
+        dict | str: The artifact graph produced by execution, or an error message.
+    """
+    logger.info("exec_kcl_project tool called")
+
+    try:
+        return zoo_exec_kcl_project(kcl_code=kcl_code, kcl_path=kcl_path)
+    except Exception as e:
+        return f"Failed to execute KCL project: {e}"
 
 
 @mcp.tool()

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -535,12 +535,16 @@ async def get_face_info(
     """Get the position, gradient, normal, and center of a face in a KCL model.
 
     Args:
-        face_id (str): The UUID of the face to query.
+        face_id (str): Intended to be a face id selected and sent by the user.
         kcl_code (str | None): The KCL code defining the model.
         kcl_path (str | None): A .kcl file or project directory containing main.kcl.
 
     Returns:
         dict | str: The face position, gradient, normal, and center, or an error message.
+                    The position is the starting point of the face's outside perimeter in KittyCAD engine space. Pretty confusing.
+                    The gradient is the direction of greatest change of a scalar function.
+                    The normal is a typical face normal.
+                    The center is the geometric center of the face. *Prefer this over the position.*
     """
     logger.info("get_face_info tool called for face_id=%s", face_id)
 

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 
 import kcl
 from kittycad.models.modeling_cmd import OptionDefaultCameraLookAt, Point3d
+from kittycad.models.uuid import Uuid
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent
 
@@ -39,6 +40,7 @@ from zoo_mcp.zoo_tools import (
     zoo_convert_cad_file,
     zoo_execute_kcl,
     zoo_export_kcl,
+    zoo_face_info,
     zoo_format_kcl,
     zoo_get_sketch_constraint_status,
     zoo_lint_and_fix_kcl,
@@ -499,6 +501,39 @@ async def get_sketch_constraint_status(
         )
     except Exception as e:
         return f"Failed to get sketch constraint status: {e}"
+
+
+@mcp.tool()
+async def get_face_info(
+    face_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the position, gradient, normal, and center of a face in a KCL model.
+
+    Args:
+        face_id (str): The UUID of the face to query.
+        kcl_code (str | None): The KCL code defining the model.
+        kcl_path (str | None): A .kcl file or project directory containing main.kcl.
+
+    Returns:
+        dict | str: The face position, gradient, normal, and center, or an error message.
+    """
+    logger.info("get_face_info tool called for face_id=%s", face_id)
+
+    try:
+        face_info = zoo_face_info(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            face_id=Uuid(face_id),
+        )
+        return {
+            "face_get_position": face_info.face_get_position.model_dump(),
+            "face_get_gradient": face_info.face_get_gradient.model_dump(),
+            "face_get_center": face_info.face_get_center.model_dump(),
+        }
+    except Exception as e:
+        return f"Failed to get face information: {e}"
 
 
 @mcp.tool()

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -1,8 +1,10 @@
 import io
+import json
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
 from uuid import uuid4
 
 import aiofiles
@@ -25,6 +27,9 @@ from kittycad.models import (
     Axis,
     AxisDirectionPair,
     Direction,
+    FaceGetCenter,
+    FaceGetGradient,
+    FaceGetPosition,
     FileCenterOfMass,
     FileConversion,
     FileExportFormat,
@@ -37,6 +42,7 @@ from kittycad.models import (
     InputFormat3d,
     ModelingCmd,
     ModelingCmdId,
+    Point2d,
     Point3d,
     PostEffectType,
     System,
@@ -59,11 +65,25 @@ from kittycad.models.input_format3d import (
 from kittycad.models.modeling_cmd import (
     OptionDefaultCameraLookAt,
     OptionDefaultCameraSetOrthographic,
+    OptionFaceGetCenter,
+    OptionFaceGetGradient,
+    OptionFaceGetPosition,
     OptionImportFiles,
     OptionTakeSnapshot,
     OptionViewIsometric,
     OptionZoomToFit,
 )
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionFaceGetCenter as ResponseFaceGetCenter,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionFaceGetGradient as ResponseFaceGetGradient,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionFaceGetPosition as ResponseFaceGetPosition,
+)
+from kittycad.models.ok_web_socket_response_data import OptionModeling
+from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
 from kittycad.models.uuid import Uuid
 from kittycad.models.web_socket_request import OptionModelingCmdReq
 
@@ -76,6 +96,25 @@ SUPPORTED_EXTS = {x.value.lower() for x in FileImportFormat} | {"stp"}
 _EXT_ALIASES = {
     "stp": "step",
 }
+
+
+def load_kcl_project(path: Path | str) -> tuple[str, list[dict[str, str | list[int]]]]:
+    """Load a KCL project into the shape expected by exec_kcl_project."""
+    path = Path(path).resolve()
+    root = path if path.is_dir() else path.parent
+    entrypoint = "main.kcl" if path.is_dir() else path.name
+
+    files: list[dict[str, str | list[int]]] = [
+        {
+            "path": file.relative_to(root).as_posix(),
+            "contents": list(file.read_bytes()),
+        }
+        for file in sorted(root.rglob("*"))
+        if file.is_file()
+    ]
+
+    return entrypoint, files
+
 
 # Mappings from user-facing short strings to kcl PyO3 enum members.
 # The kcl unit enums cannot be constructed from strings directly.
@@ -2040,6 +2079,159 @@ def zoo_snapshot_of_cad(
         jpeg_contents = message["resp"]["data"]["modeling_response"]["data"]["contents"]
 
         return resize_image(jpeg_contents, max_image_dimension)
+
+@dataclass
+class FaceInfo:
+    face_get_position: FaceGetPosition
+    face_get_gradient: FaceGetGradient
+    face_get_center: FaceGetCenter
+
+
+def zoo_face_info(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    face_id: Uuid,
+) -> FaceInfo:
+    """Get the position, gradient, and center of a face in a KCL project."""
+    _check_kcl_code_or_path(kcl_code, kcl_path)
+
+    if kcl_code:
+        entrypoint = "main.kcl"
+        files: list[dict[str, str | list[int]]] = [
+            {
+                "path": entrypoint,
+                "contents": list(kcl_code.encode()),
+            }
+        ]
+    else:
+        assert kcl_path is not None
+        entrypoint, files = load_kcl_project(kcl_path)
+
+    with kittycad_client.modeling.modeling_commands_ws(
+        fps=30,
+        post_effect=PostEffectType.SSAO,
+        show_grid=False,
+        unlocked_framerate=False,
+        video_res_height=1024,
+        video_res_width=1024,
+        webrtc=False,
+    ) as ws:
+        # This protocol message is not represented in the generated SDK yet.
+        cmd_id_exec_kcl_project = ModelingCmdId(uuid4())
+        request = {
+            "type": "exec_kcl_project",
+            "request_id": cmd_id_exec_kcl_project,
+            "project": {
+                "entrypoint": entrypoint,
+                "files": files,
+            },
+        }
+        ws.ws.send(json.dumps(request))
+
+        # Its response is also absent from the SDK, so consume it as raw JSON.
+        while True:
+            raw_response = ws.ws.recv()
+            try:
+                response = json.loads(raw_response)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if response.get("request_id") != cmd_id_exec_kcl_project:
+                continue
+            if not response.get("success", False):
+                raise ZooMCPException("Failed to execute KCL project")
+            payload = response.get("resp", {})
+            if payload.get("type") != "exec_kcl_project":
+                continue
+            result = payload.get("data", {}).get("result")
+            if isinstance(result, dict):
+                lowered_result = {str(key).lower(): value for key, value in result.items()}
+                if "err" in lowered_result or "error" in lowered_result:
+                    error = lowered_result.get("err", lowered_result.get("error"))
+                    raise ZooMCPException(f"Failed to execute KCL project: {error}")
+            break
+
+        cmd_id_face_get_position = ModelingCmdId(uuid4())
+        ws.send(
+            WebSocketRequest(
+                OptionModelingCmdReq(
+                    cmd=ModelingCmd(
+                        OptionFaceGetPosition(
+                            object_id=face_id,
+                            uv=Point2d(x=0.5, y=0.5),
+                        )
+                    ),
+                    cmd_id=cmd_id_face_get_position,
+                )
+            )
+        )
+
+        cmd_id_face_get_gradient = ModelingCmdId(uuid4())
+        ws.send(
+            WebSocketRequest(
+                OptionModelingCmdReq(
+                    cmd=ModelingCmd(
+                        OptionFaceGetGradient(
+                            object_id=face_id,
+                            uv=Point2d(x=0.5, y=0.5),
+                        )
+                    ),
+                    cmd_id=cmd_id_face_get_gradient,
+                )
+            )
+        )
+
+        cmd_id_face_get_center = ModelingCmdId(uuid4())
+        ws.send(
+            WebSocketRequest(
+                OptionModelingCmdReq(
+                    cmd=ModelingCmd(OptionFaceGetCenter(object_id=face_id)),
+                    cmd_id=cmd_id_face_get_center,
+                )
+            )
+        )
+
+        face_get_position: FaceGetPosition | Literal[False] = False
+        face_get_gradient: FaceGetGradient | Literal[False] = False
+        face_get_center: FaceGetCenter | Literal[False] = False
+
+        while (
+            face_get_position is False
+            or face_get_gradient is False
+            or face_get_center is False
+        ):
+            message = ws.recv().root
+            if not isinstance(message, SuccessWebSocketResponse):
+                raise ZooMCPException(message)
+            if message.request_id not in {
+                cmd_id_face_get_position,
+                cmd_id_face_get_gradient,
+                cmd_id_face_get_center,
+            }:
+                continue
+
+            response = message.resp.root
+            if not isinstance(response, OptionModeling):
+                raise ZooMCPException("Received an unexpected websocket response")
+            modeling_response = response.data.modeling_response.root
+
+            if message.request_id == cmd_id_face_get_position:
+                if not isinstance(modeling_response, ResponseFaceGetPosition):
+                    raise ZooMCPException("Received an unexpected face position response")
+                face_get_position = modeling_response.data
+            elif message.request_id == cmd_id_face_get_gradient:
+                if not isinstance(modeling_response, ResponseFaceGetGradient):
+                    raise ZooMCPException("Received an unexpected face gradient response")
+                face_get_gradient = modeling_response.data
+            elif message.request_id == cmd_id_face_get_center:
+                if not isinstance(modeling_response, ResponseFaceGetCenter):
+                    raise ZooMCPException("Received an unexpected face center response")
+                face_get_center = modeling_response.data
+
+        return FaceInfo(
+            face_get_position=face_get_position,
+            face_get_gradient=face_get_gradient,
+            face_get_center=face_get_center,
+        )
 
 
 async def zoo_snapshot_of_kcl(

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 import aiofiles
 import kcl
 import trimesh
+from kittycad import WebSocketModelingCommandsWs
 
 if TYPE_CHECKING:
 
@@ -2080,11 +2081,90 @@ def zoo_snapshot_of_cad(
 
         return resize_image(jpeg_contents, max_image_dimension)
 
+
 @dataclass
 class FaceInfo:
     face_get_position: FaceGetPosition
     face_get_gradient: FaceGetGradient
     face_get_center: FaceGetCenter
+
+
+def _prepare_kcl_project(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+) -> tuple[str, list[dict[str, str | list[int]]]]:
+    _check_kcl_code_or_path(kcl_code, kcl_path)
+
+    if kcl_code:
+        return "main.kcl", [
+            {
+                "path": "main.kcl",
+                "contents": list(kcl_code.encode()),
+            }
+        ]
+
+    assert kcl_path is not None
+    return load_kcl_project(kcl_path)
+
+
+def _exec_kcl_project(
+    ws: WebSocketModelingCommandsWs,
+    entrypoint: str,
+    files: list[dict[str, str | list[int]]],
+) -> dict:
+    """Execute a KCL project through the server-side websocket protocol."""
+    request_id = ModelingCmdId(uuid4())
+    request = {
+        "type": "exec_kcl_project",
+        "request_id": request_id,
+        "project": {
+            "entrypoint": entrypoint,
+            "files": files,
+        },
+    }
+    ws.ws.send(json.dumps(request))
+
+    # This response is not represented in the generated SDK yet.
+    while True:
+        raw_response = ws.ws.recv()
+        try:
+            response = json.loads(raw_response)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if response.get("request_id") != request_id:
+            continue
+        if not response.get("success", False):
+            raise ZooMCPException("Failed to execute KCL project")
+        payload = response.get("resp", {})
+        if payload.get("type") != "exec_kcl_project":
+            continue
+
+        result = payload.get("data", {}).get("result")
+        if not isinstance(result, dict):
+            raise ZooMCPException("KCL project execution returned no result")
+        lowered_result = {str(key).lower(): value for key, value in result.items()}
+        if "err" in lowered_result or "error" in lowered_result:
+            error = lowered_result.get("err", lowered_result.get("error"))
+            raise ZooMCPException(f"Failed to execute KCL project: {error}")
+
+        success = lowered_result.get("ok")
+        if not isinstance(success, dict):
+            raise ZooMCPException("KCL project execution returned no success result")
+        artifact_graph = success.get("artifact_graph")
+        if not isinstance(artifact_graph, dict):
+            raise ZooMCPException("KCL project execution returned no artifact graph")
+        return artifact_graph
+
+
+def zoo_exec_kcl_project(
+    kcl_code: str | None = None,
+    kcl_path: Path | str | None = None,
+) -> dict:
+    """Run a KCL project on the server side and return its artifact graph."""
+    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
+
+    with kittycad_client.modeling.modeling_commands_ws(webrtc=False) as ws:
+        return _exec_kcl_project(ws, entrypoint, files)
 
 
 def zoo_face_info(
@@ -2093,19 +2173,7 @@ def zoo_face_info(
     face_id: Uuid,
 ) -> FaceInfo:
     """Get the position, gradient, and center of a face in a KCL project."""
-    _check_kcl_code_or_path(kcl_code, kcl_path)
-
-    if kcl_code:
-        entrypoint = "main.kcl"
-        files: list[dict[str, str | list[int]]] = [
-            {
-                "path": entrypoint,
-                "contents": list(kcl_code.encode()),
-            }
-        ]
-    else:
-        assert kcl_path is not None
-        entrypoint, files = load_kcl_project(kcl_path)
+    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
 
     with kittycad_client.modeling.modeling_commands_ws(
         fps=30,
@@ -2116,39 +2184,7 @@ def zoo_face_info(
         video_res_width=1024,
         webrtc=False,
     ) as ws:
-        # This protocol message is not represented in the generated SDK yet.
-        cmd_id_exec_kcl_project = ModelingCmdId(uuid4())
-        request = {
-            "type": "exec_kcl_project",
-            "request_id": cmd_id_exec_kcl_project,
-            "project": {
-                "entrypoint": entrypoint,
-                "files": files,
-            },
-        }
-        ws.ws.send(json.dumps(request))
-
-        # Its response is also absent from the SDK, so consume it as raw JSON.
-        while True:
-            raw_response = ws.ws.recv()
-            try:
-                response = json.loads(raw_response)
-            except (TypeError, json.JSONDecodeError):
-                continue
-            if response.get("request_id") != cmd_id_exec_kcl_project:
-                continue
-            if not response.get("success", False):
-                raise ZooMCPException("Failed to execute KCL project")
-            payload = response.get("resp", {})
-            if payload.get("type") != "exec_kcl_project":
-                continue
-            result = payload.get("data", {}).get("result")
-            if isinstance(result, dict):
-                lowered_result = {str(key).lower(): value for key, value in result.items()}
-                if "err" in lowered_result or "error" in lowered_result:
-                    error = lowered_result.get("err", lowered_result.get("error"))
-                    raise ZooMCPException(f"Failed to execute KCL project: {error}")
-            break
+        _exec_kcl_project(ws, entrypoint, files)
 
         cmd_id_face_get_position = ModelingCmdId(uuid4())
         ws.send(
@@ -2216,11 +2252,15 @@ def zoo_face_info(
 
             if message.request_id == cmd_id_face_get_position:
                 if not isinstance(modeling_response, ResponseFaceGetPosition):
-                    raise ZooMCPException("Received an unexpected face position response")
+                    raise ZooMCPException(
+                        "Received an unexpected face position response"
+                    )
                 face_get_position = modeling_response.data
             elif message.request_id == cmd_id_face_get_gradient:
                 if not isinstance(modeling_response, ResponseFaceGetGradient):
-                    raise ZooMCPException("Received an unexpected face gradient response")
+                    raise ZooMCPException(
+                        "Received an unexpected face gradient response"
+                    )
                 face_get_gradient = modeling_response.data
             elif message.request_id == cmd_id_face_get_center:
                 if not isinstance(modeling_response, ResponseFaceGetCenter):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -438,6 +438,67 @@ async def test_execute_kcl_error():
     assert "Failed to execute KCL code" in result[1]
 
 
+def test_exec_kcl_project_extracts_artifact_graph():
+    raw_socket = MagicMock()
+
+    def recv():
+        request = json.loads(raw_socket.send.call_args.args[0])
+        return json.dumps(
+            {
+                "success": True,
+                "request_id": request["request_id"],
+                "resp": {
+                    "type": "exec_kcl_project",
+                    "data": {
+                        "result": {
+                            "ok": {
+                                "artifact_graph": {
+                                    "map": {"artifact-id": {"type": "solid2d"}},
+                                    "item_count": 1,
+                                }
+                            }
+                        }
+                    },
+                },
+            }
+        )
+
+    raw_socket.recv.side_effect = recv
+    websocket = SimpleNamespace(ws=raw_socket)
+
+    result = zoo_mcp.zoo_tools._exec_kcl_project(
+        cast(Any, websocket),
+        "main.kcl",
+        [{"path": "main.kcl", "contents": list(b"sketch = startSketchOn(XY)")}],
+    )
+
+    assert result == {
+        "map": {"artifact-id": {"type": "solid2d"}},
+        "item_count": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_exec_kcl_project_tool(monkeypatch):
+    artifact_graph = {
+        "map": {"artifact-id": {"type": "solid2d"}},
+        "item_count": 1,
+    }
+    mock = MagicMock(return_value=artifact_graph)
+    monkeypatch.setattr("zoo_mcp.server.zoo_exec_kcl_project", mock)
+
+    response = await mcp.call_tool(
+        "exec_kcl_project",
+        arguments={"kcl_code": "sketch = startSketchOn(XY)", "kcl_path": None},
+    )
+
+    assert _meta_result(response) == artifact_graph
+    mock.assert_called_once_with(
+        kcl_code="sketch = startSketchOn(XY)",
+        kcl_path=None,
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_kcl_surfaces_warning_issue(warning_kcl: str):
     """A non-fatal warning (disjoint union) succeeds but is reported."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -874,6 +874,54 @@ async def test_get_sketch_constraint_status_error():
 
 
 @pytest.mark.asyncio
+async def test_get_face_info(monkeypatch):
+    face_info = SimpleNamespace(
+        face_get_position=MagicMock(
+            model_dump=MagicMock(return_value={"pos": {"x": 1.0, "y": 2.0, "z": 3.0}})
+        ),
+        face_get_gradient=MagicMock(
+            model_dump=MagicMock(
+                return_value={
+                    "df_du": {"x": 1.0, "y": 0.0, "z": 0.0},
+                    "df_dv": {"x": 0.0, "y": 1.0, "z": 0.0},
+                    "normal": {"x": 0.0, "y": 0.0, "z": 1.0},
+                }
+            )
+        ),
+        face_get_center=MagicMock(
+            model_dump=MagicMock(return_value={"pos": {"x": 0.5, "y": 0.5, "z": 0.0}})
+        ),
+    )
+    mock = MagicMock(return_value=face_info)
+    monkeypatch.setattr("zoo_mcp.server.zoo_face_info", mock)
+
+    response = await mcp.call_tool(
+        "get_face_info",
+        arguments={
+            "face_id": "face-id",
+            "kcl_code": "cube = startSketchOn(XY)",
+            "kcl_path": None,
+        },
+    )
+
+    result = _meta_result(response)
+    assert result == {
+        "face_get_position": {"pos": {"x": 1.0, "y": 2.0, "z": 3.0}},
+        "face_get_gradient": {
+            "df_du": {"x": 1.0, "y": 0.0, "z": 0.0},
+            "df_dv": {"x": 0.0, "y": 1.0, "z": 0.0},
+            "normal": {"x": 0.0, "y": 0.0, "z": 1.0},
+        },
+        "face_get_center": {"pos": {"x": 0.5, "y": 0.5, "z": 0.0}},
+    }
+    mock.assert_called_once_with(
+        kcl_code="cube = startSketchOn(XY)",
+        kcl_path=None,
+        face_id="face-id",
+    )
+
+
+@pytest.mark.asyncio
 async def test_mock_execute_kcl(cube_kcl: str):
     response = await mcp.call_tool(
         "mock_execute_kcl",

--- a/uv.lock
+++ b/uv.lock
@@ -1123,20 +1123,20 @@ wheels = [
 
 [[package]]
 name = "zoo-kcl"
-version = "0.3.174"
+version = "0.3.175"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/c0/f3da62fca7158e364fd3f3dce21965b6b216dbfb6033f3c480802167f4a8/zoo_kcl-0.3.174.tar.gz", hash = "sha256:18c8a7ae449cbf70611857266cfac26fa34c14c8cfb805ea8aab350efba0c88c", size = 1055499, upload-time = "2026-07-31T21:38:44.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/05/2224505f86cb051c15e8ce9a1f41382b37004040ea5e2a0a23e6316ebcf9/zoo_kcl-0.3.175.tar.gz", hash = "sha256:eff034e3f5e69a73a18f53980beb6ae9d0ed167b433cf6b33da96af09c520789", size = 1164189, upload-time = "2026-08-07T16:08:30.969Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/78/3b44ba87fdab98f81793309d6169b47bf9980114d27f95dc874a075c15b5/zoo_kcl-0.3.174-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c08a5747d25cf09c20b9db35b4ca7b6e76c938f6b5c9c3739f131041cc7d8180", size = 7531364, upload-time = "2026-07-31T21:38:37.368Z" },
-    { url = "https://files.pythonhosted.org/packages/43/7f/2bdb4c679e1a408e5c1d5f28c242a9a7384d6874e5bb3153391bc4d9d49e/zoo_kcl-0.3.174-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edece4465bfb5bc1c0ca8c1be448863aff45d334799a0892d68f78e7a60fdc46", size = 8791441, upload-time = "2026-07-31T21:38:22.091Z" },
-    { url = "https://files.pythonhosted.org/packages/88/b1/b2d58bca4387226f084b6fed52b90ba7db79998aa0843bb9c6a2b02c81ac/zoo_kcl-0.3.174-cp311-cp311-win_amd64.whl", hash = "sha256:c4a30a58716bb387de2d7e30c399511d33c3954ce96b47a2656ab67d7baea7a2", size = 8641265, upload-time = "2026-07-31T21:38:45.633Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fb/a5fdec34f454ff35176c2bcc2bd7e91b71144f09d30ce619ea641fb4462c/zoo_kcl-0.3.174-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2cfe3b9b1e3c3ab934e9d6cc4b5b90303e3bea7d46a523b35c8b86df9b5858e7", size = 7525738, upload-time = "2026-07-31T21:38:39.289Z" },
-    { url = "https://files.pythonhosted.org/packages/81/9b/ff23005eebd9450af6089c29cba49489a1c97122a1530f21f42e86e7a01e/zoo_kcl-0.3.174-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a39f2653bf2193077ad09953ec776304f7f4cd9e66a1408334b2a2d4e5cc1c", size = 8791818, upload-time = "2026-07-31T21:38:24.144Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/d3/6415a84d41272460be5e0d116eecd693fda2b5cacfc587078c956caff08e/zoo_kcl-0.3.174-cp312-cp312-win_amd64.whl", hash = "sha256:1d62d93dd1f45a74b955d1e351b17880685b07c4c99c6ea9abbbd52e40be24c4", size = 8644696, upload-time = "2026-07-31T21:38:47.522Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/31/7614d671786dd1a9b7448e6392445efd13099e9bef53a08964cd60491484/zoo_kcl-0.3.174-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5cd8045a15c2ad0c2ca96f6ef5cee2a5f89ddba405099a3ab5ae13e43c6e2242", size = 7525472, upload-time = "2026-07-31T21:38:40.844Z" },
-    { url = "https://files.pythonhosted.org/packages/14/04/93c351f867f9fbf901dbcfa301c0a38eb366b2cd60b424b04d11272e5af2/zoo_kcl-0.3.174-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1e41def02c017480c557df0f5fec6d61a8384311b42c83594b1586acbc0ffb1", size = 8790712, upload-time = "2026-07-31T21:38:26.481Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/55/ce4730093a2a8ddad5f1fe7eaea68da01ff295c9e84bf6fa62cabc9d0e2d/zoo_kcl-0.3.174-cp313-cp313-win_amd64.whl", hash = "sha256:a59712e1f932ea22bc21532ab1a53c7bdde59ffb9f41df7ab5841c9ccea14a72", size = 8644244, upload-time = "2026-07-31T21:38:49.395Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/41/fe1e5235f3e336b12f9d2e15b48eef66dedecac0658989772e0eb5123cc7/zoo_kcl-0.3.174-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02477e93f178e45a49477b0db13db085d937b984ddc222c6eddf1cd0cface4a4", size = 8795519, upload-time = "2026-07-31T21:38:35.525Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/c3c5f0eea9adb8790ec8e5ba76acb518f2c7e72ef2b8900ac37681ddb31b/zoo_kcl-0.3.175-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3c0cb25febed47ca04939884a265a1288c688d4846ce1ac20520da2daf03ef1b", size = 7570397, upload-time = "2026-08-07T16:08:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/4772ae39721d458d861c9be26c1e9cc3d6e40dd4ba0a9d73d739dde8eede/zoo_kcl-0.3.175-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee11d72c38880f8dad28f214f2a21bc9e6721fbe54449ea0e671925de9f59ebb", size = 8842850, upload-time = "2026-08-07T16:08:13.816Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/c6f491779fa07c0804a3102772f244695698ae1e09cc06e99f933558249a/zoo_kcl-0.3.175-cp311-cp311-win_amd64.whl", hash = "sha256:d9b1e7e3bc0eaa5fd8e263223631292edfdfe18bd5b4dea513e30eaaa1ad2438", size = 8679404, upload-time = "2026-08-07T16:08:32.098Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bb/3550f5cb8f4847f0a18b333c2daf1d6ca4f3a79c7402054e39e9bf9b1851/zoo_kcl-0.3.175-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0cca9860f3fb4e671456206ba90715995a4d069920a89b62e5d4a6f074cc6962", size = 7560921, upload-time = "2026-08-07T16:08:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/44/49/8076e7a1d3c6f1c47f35dd180044ece21fac409d1e5610d63b0bc8313fb6/zoo_kcl-0.3.175-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d398b1a3f0a4337bce410a413f4e1c73d0bb9b6b1c0d45fd676381eeb3662f6", size = 8829680, upload-time = "2026-08-07T16:08:15.734Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/4a3b0db665f57a4ccd5012e45a0dc4df01526f6dfbaa90cffaf026bf2da4/zoo_kcl-0.3.175-cp312-cp312-win_amd64.whl", hash = "sha256:b0ff005d9ceaffce4136e279f54f878546cca00be186486dbac0aa7d6da8e209", size = 8678833, upload-time = "2026-08-07T16:08:33.7Z" },
+    { url = "https://files.pythonhosted.org/packages/56/09/f27c38936dde3a3f27c8ae2388fbde41e1c785de7279f5794884635c30dd/zoo_kcl-0.3.175-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:af5a6eb96ee005864e0e1dcaef4c6a39b928f7ee24dbf3a4938c9f2e52d5ee86", size = 7560614, upload-time = "2026-08-07T16:08:28.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/23/37d6579d00368209e1c50e3657a1eb304627421e0b6acff81adcce8b8c9a/zoo_kcl-0.3.175-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328d98f884b3ce411efa2210825393e19299cc51938335754c67809718972ad2", size = 8828970, upload-time = "2026-08-07T16:08:17.54Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e2/ad7132105fd67ed84585327c43c1f2750f358df746f46b1a5ebedb30f413/zoo_kcl-0.3.175-cp313-cp313-win_amd64.whl", hash = "sha256:73056ae71d8345a19abd7cf704b58a63a3ac14a9afcf8ba3e372db1baf6b9f0d", size = 8677363, upload-time = "2026-08-07T16:08:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b0/9283fb92f679a41ade9f6ea36af430e6790d2b872396bcffba802620f7c6/zoo_kcl-0.3.175-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48de601cf913f94ec1ae2eda6c9a2cabde4fdb7993400a7cd6af30a3d19e5909", size = 8838374, upload-time = "2026-08-07T16:08:23.233Z" },
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ requires-dist = [
     { name = "trimesh", specifier = "<5.0" },
     { name = "truststore", specifier = "<1.0" },
     { name = "typing-extensions", specifier = ">=4.12" },
-    { name = "zoo-kcl", specifier = ">=0.3.174" },
+    { name = "zoo-kcl", specifier = ">=0.3.175" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.18.3"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
We have engine commands to get valuable, orienting face information from models. This should help solve the problem of Zookeeper struggling to position model features on particular faces.

Additionally I expose the exec_kcl_project tool. While testing this PR with codex it wanted the artifact graph, which `execute_kcl` doesn't return. I used AI to add this very thin wrapper.

The intention of this PR is for users to use *face selections* with the tool call through Zookeeper, *but Zookeeper may try to decide on its own what face is which*, needing the artifact graph.

I've also added some minor documentation around the architecture / mental model of this repository. 