### PR TITLE
Add modeling query tools and persistent sessions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,4 +30,4 @@ jobs:
           ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           ZOO_DATASET_TOKEN: ${{ secrets.ZOO_DATASET_TOKEN }}
         run: |
-          uv run pytest -n 8 --dist loadscope -vv --log-cli-level=INFO
+          uv run pytest -n 8 --dist loadgroup -vv --log-cli-level=INFO

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,4 +30,4 @@ jobs:
           ZOO_API_TOKEN: ${{ secrets.ZOO_API_TOKEN }}
           ZOO_DATASET_TOKEN: ${{ secrets.ZOO_DATASET_TOKEN }}
         run: |
-          uv run pytest -n 8 -vv --log-cli-level=INFO
+          uv run pytest -n 8 --dist loadscope -vv --log-cli-level=INFO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.19.0"
+version = "0.20.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.19.0",
+  "version": "0.20.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -6,6 +6,7 @@ import kcl
 from kittycad.models import (
     CurveGetEndPoints,
     CurveGetType,
+    DistanceType,
     EdgeGetLength,
     EngineUtilEvaluatePath,
     EntityGetAllChildUuids,
@@ -17,10 +18,63 @@ from kittycad.models import (
     EntityType,
     GlobalAxis,
     HighlightSetEntities,
+    ModelingCmd,
     SelectEntity,
     SetSelectionFilter,
 )
-from kittycad.models.modeling_cmd import OptionDefaultCameraLookAt, Point3d
+from kittycad.models.distance_type import OptionEuclidean, OptionOnAxis
+from kittycad.models.modeling_cmd import (
+    OptionCurveGetEndPoints,
+    OptionCurveGetType,
+    OptionDefaultCameraLookAt,
+    OptionEdgeGetLength,
+    OptionEngineUtilEvaluatePath,
+    OptionEntityGetAllChildUuids,
+    OptionEntityGetDistance,
+    OptionEntityGetIndex,
+    OptionEntityGetParentId,
+    OptionEntityGetSketchPaths,
+    OptionHighlightSetEntities,
+    OptionSelectEntity,
+    OptionSetSelectionFilter,
+    Point3d,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionCurveGetEndPoints as ResponseCurveGetEndPoints,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionCurveGetType as ResponseCurveGetType,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEdgeGetLength as ResponseEdgeGetLength,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEngineUtilEvaluatePath as ResponseEngineUtilEvaluatePath,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetAllChildUuids as ResponseEntityGetAllChildUuids,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetDistance as ResponseEntityGetDistance,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetIndex as ResponseEntityGetIndex,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetParentId as ResponseEntityGetParentId,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetSketchPaths as ResponseEntityGetSketchPaths,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionHighlightSetEntities as ResponseHighlightSetEntities,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionSelectEntity as ResponseSelectEntity,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionSetSelectionFilter as ResponseSetSelectionFilter,
+)
 from kittycad.models.uuid import Uuid
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent
@@ -56,22 +110,13 @@ from zoo_mcp.zoo_tools import (
     zoo_calculate_surface_area,
     zoo_calculate_volume,
     zoo_convert_cad_file,
-    zoo_curve_get_end_points,
-    zoo_curve_get_type,
-    zoo_edge_get_length,
-    zoo_engine_util_evaluate_path,
-    zoo_entity_distance,
-    zoo_entity_get_all_child_uuids,
-    zoo_entity_get_index,
-    zoo_entity_get_parent_id,
-    zoo_entity_get_sketch_paths,
     zoo_exec_kcl_project,
     zoo_execute_kcl,
+    zoo_execute_modeling_command,
     zoo_export_kcl,
     zoo_face_info,
     zoo_format_kcl,
     zoo_get_sketch_constraint_status,
-    zoo_highlight_set_entities,
     zoo_lint_and_fix_kcl,
     zoo_list_org_datasets,
     zoo_list_org_skills,
@@ -81,8 +126,6 @@ from zoo_mcp.zoo_tools import (
     zoo_multiview_snapshot_of_cad,
     zoo_multiview_snapshot_of_kcl,
     zoo_search_org_dataset_semantic,
-    zoo_select_entity,
-    zoo_set_selection_filter,
     zoo_snapshot,
     zoo_snapshot_of_cad,
     zoo_snapshot_of_kcl,
@@ -657,68 +700,114 @@ async def entity_distance(
         EntityGetDistance: The minimum and maximum distance between the entities.
     """
     logger.info("entity_distance tool called")
-    return zoo_entity_distance(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_id1=Uuid(entity_id1),
-        entity_id2=Uuid(entity_id2),
-        on_axis=on_axis,
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(
+            OptionEntityGetDistance(
+                entity_id1=Uuid(entity_id1),
+                entity_id2=Uuid(entity_id2),
+                distance_type=DistanceType(
+                    OptionOnAxis(axis=on_axis)
+                    if on_axis is not None
+                    else OptionEuclidean()
+                ),
+            )
+        ),
+        ResponseEntityGetDistance,
+        "entity distance",
+        session_id,
+    ).data
+
+
+# Selection and highlight commands mutate engine scene state, so they only make
+# sense against a session that outlives the call. Executing KCL just to set a
+# selection would discard the scene, and the selection with it.
 
 
 @mcp.tool()
 async def set_selection_filter(
     entity_types: list[EntityType],
-    kcl_code: str | None = None,
-    kcl_path: str | None = None,
-    session_id: str | None = None,
+    session_id: str,
 ) -> SetSelectionFilter:
     """Set which model entity types can be added to the "selection set".
 
     Args:
         entity_types: Entity types permitted by the selection filter.
-        kcl_code: KCL code defining the model.
-        kcl_path: A .kcl file or project directory containing main.kcl.
-        session_id: An open modeling session to reuse instead of executing KCL again.
+        session_id: An open modeling session, from start_modeling_session. Required:
+                    the filter is scene state and would be discarded without one.
 
     Returns:
         SetSelectionFilter: Confirmation that the filter was set.
     """
     logger.info("set_selection_filter tool called")
-    return zoo_set_selection_filter(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_types=entity_types,
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        None,
+        None,
+        ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
+        ResponseSetSelectionFilter,
+        "selection filter",
+        session_id,
+    ).data
 
 
 @mcp.tool()
 async def select_entity(
     entities: list[EntityReference],
-    kcl_code: str | None = None,
-    kcl_path: str | None = None,
-    session_id: str | None = None,
+    session_id: str,
 ) -> SelectEntity:
     """Replace the current "selection set" with explicit entity references.
 
     Args:
         entities: Typed face, edge, solid, segment, or other entity references.
-        kcl_code: KCL code defining the model.
-        kcl_path: A .kcl file or project directory containing main.kcl.
-        session_id: An open modeling session to reuse instead of executing KCL again.
+        session_id: An open modeling session, from start_modeling_session. Required:
+                    the selection is scene state and would be discarded without one.
 
     Returns:
         SelectEntity: Confirmation that the selection was replaced.
     """
     logger.info("select_entity tool called")
-    return zoo_select_entity(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entities=entities,
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        None,
+        None,
+        ModelingCmd(OptionSelectEntity(entities=entities)),
+        ResponseSelectEntity,
+        "select entity",
+        session_id,
+    ).data
+
+
+@mcp.tool()
+async def highlight_set_entities(
+    entity_ids: list[str],
+    session_id: str,
+) -> HighlightSetEntities:
+    """Replace the currently highlighted entities. Does NOT modify the "selection set".
+
+    This is a visual command: follow it with the `snapshot` tool, passing the same
+    session_id and zoom=False, to see the highlight without moving the camera. It
+    highlights edges, surfaces and bodies.
+
+    Args:
+        entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.
+        session_id: An open modeling session, from start_modeling_session. Required:
+                    highlights are scene state and would be discarded without one.
+
+    Returns:
+        HighlightSetEntities: Confirmation that the highlights were replaced.
+    """
+    logger.info("highlight_set_entities tool called")
+    return zoo_execute_modeling_command(
+        None,
+        None,
+        ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
+        ResponseHighlightSetEntities,
+        "highlight entities",
+        session_id,
+    ).data
+
+
+# Get information around curves and segments.
 
 
 @mcp.tool()
@@ -740,12 +829,14 @@ async def curve_get_end_points(
         CurveGetEndPoints: The curve's start and end points.
     """
     logger.info("curve_get_end_points tool called")
-    return zoo_curve_get_end_points(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        curve_id=Uuid(curve_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionCurveGetEndPoints(curve_id=Uuid(curve_id))),
+        ResponseCurveGetEndPoints,
+        "curve endpoints",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -805,13 +896,14 @@ async def engine_util_evaluate_path(
         EngineUtilEvaluatePath: The position on the path at parameter t.
     """
     logger.info("engine_util_evaluate_path tool called")
-    return zoo_engine_util_evaluate_path(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        path_json=path_json,
-        t=t,
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
+        ResponseEngineUtilEvaluatePath,
+        "path evaluation",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -823,16 +915,24 @@ async def curve_get_type(
 ) -> CurveGetType:
     """Get whether a curve is a line, arc, or NURBS curve.
 
+    Args:
+        curve_id: Curve UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
+
     Returns:
         CurveGetType: The curve's geometric type.
     """
     logger.info("curve_get_type tool called")
-    return zoo_curve_get_type(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        curve_id=Uuid(curve_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionCurveGetType(curve_id=Uuid(curve_id))),
+        ResponseCurveGetType,
+        "curve type",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -844,16 +944,27 @@ async def edge_get_length(
 ) -> EdgeGetLength:
     """Get the length of an edge entity in the current scene units.
 
+    Args:
+        edge_id: Edge UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
+
     Returns:
         EdgeGetLength: The edge length in the current scene units.
     """
     logger.info("edge_get_length tool called")
-    return zoo_edge_get_length(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        edge_id=Uuid(edge_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEdgeGetLength(edge_id=Uuid(edge_id))),
+        ResponseEdgeGetLength,
+        "edge length",
+        session_id,
+    ).data
+
+
+# Entity relationship tools.
 
 
 @mcp.tool()
@@ -865,16 +976,24 @@ async def entity_get_all_child_uuids(
 ) -> EntityGetAllChildUuids:
     """Get all child UUIDs belonging to an entity.
 
+    Args:
+        entity_id: Entity UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
+
     Returns:
         EntityGetAllChildUuids: All child entity UUIDs.
     """
     logger.info("entity_get_all_child_uuids tool called")
-    return zoo_entity_get_all_child_uuids(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_id=Uuid(entity_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetAllChildUuids(entity_id=Uuid(entity_id))),
+        ResponseEntityGetAllChildUuids,
+        "entity child IDs",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -886,16 +1005,24 @@ async def entity_get_index(
 ) -> EntityGetIndex:
     """Get an entity's index within its parent.
 
+    Args:
+        entity_id: Entity UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
+
     Returns:
         EntityGetIndex: The entity's index within its parent.
     """
     logger.info("entity_get_index tool called")
-    return zoo_entity_get_index(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_id=Uuid(entity_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetIndex(entity_id=Uuid(entity_id))),
+        ResponseEntityGetIndex,
+        "entity index",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -907,16 +1034,24 @@ async def entity_get_parent_id(
 ) -> EntityGetParentId:
     """Get the UUID of an entity's parent.
 
+    Args:
+        entity_id: Entity UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
+
     Returns:
         EntityGetParentId: The parent entity's UUID.
     """
     logger.info("entity_get_parent_id tool called")
-    return zoo_entity_get_parent_id(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_id=Uuid(entity_id),
-        session_id=session_id,
-    )
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetParentId(entity_id=Uuid(entity_id))),
+        ResponseEntityGetParentId,
+        "entity parent ID",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -928,46 +1063,24 @@ async def entity_get_sketch_paths(
 ) -> EntityGetSketchPaths:
     """Get the sketch path UUIDs belonging to an entity.
 
-    Returns:
-        EntityGetSketchPaths: The sketch path UUIDs belonging to the entity.
-    """
-    logger.info("entity_get_sketch_paths tool called")
-    return zoo_entity_get_sketch_paths(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_id=Uuid(entity_id),
-        session_id=session_id,
-    )
-
-
-@mcp.tool()
-async def highlight_set_entities(
-    entity_ids: list[str],
-    kcl_code: str | None = None,
-    kcl_path: str | None = None,
-    session_id: str | None = None,
-) -> HighlightSetEntities:
-    """Replace the currently highlighted entities. Does NOT modify the "selection set".
-
-    This is a visual command, meaning the `snapshot` tool must be followed up with
-    to see the result. It highlights edges, surfaces and bodies.
-
     Args:
-        entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.
+        entity_id: Entity UUID, typically obtained from an artifact graph.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        HighlightSetEntities: Confirmation that the highlights were replaced.
+        EntityGetSketchPaths: The sketch path UUIDs belonging to the entity.
     """
-    logger.info("highlight_set_entities tool called")
-    return zoo_highlight_set_entities(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        entity_ids=entity_ids,
-        session_id=session_id,
-    )
+    logger.info("entity_get_sketch_paths tool called")
+    return zoo_execute_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetSketchPaths(entity_id=Uuid(entity_id))),
+        ResponseEntityGetSketchPaths,
+        "entity sketch paths",
+        session_id,
+    ).data
 
 
 @mcp.tool()
@@ -976,19 +1089,23 @@ async def snapshot(
     kcl_path: str | None = None,
     session_id: str | None = None,
     max_image_dimension: int = 512,
+    zoom: bool = True,
 ) -> ImageContent:
     """Take a snapshot of a KCL model or the current modeling session.
 
     Provide kcl_code or kcl_path to execute a model in a temporary scene. To
     capture an existing scene without re-executing KCL, provide the session_id
-    returned by start_modeling_session. A session snapshot uses the scene's
-    current camera state.
+    returned by start_modeling_session.
 
     Args:
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to capture.
         max_image_dimension: Maximum width or height of the returned JPEG.
+        zoom: Point the camera isometrically and zoom to fit before capturing.
+              Leave True unless you have positioned the session's camera
+              yourself; a freshly executed scene is not framed, so zoom=False
+              renders the model only a few pixels wide.
 
     Returns:
         ImageContent: A JPEG snapshot of the current scene.
@@ -1000,6 +1117,7 @@ async def snapshot(
             kcl_path=kcl_path,
             session_id=session_id,
             max_image_dimension=max_image_dimension,
+            zoom=zoom,
         )
     )
 

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -17,10 +17,7 @@ from kittycad.models import (
     EntityType,
     GlobalAxis,
     HighlightSetEntities,
-    Point2d,
-    SceneSelectionType,
     SelectEntity,
-    SelectWithPoint,
     SetSelectionFilter,
 )
 from kittycad.models.modeling_cmd import OptionDefaultCameraLookAt, Point3d
@@ -85,8 +82,8 @@ from zoo_mcp.zoo_tools import (
     zoo_multiview_snapshot_of_kcl,
     zoo_search_org_dataset_semantic,
     zoo_select_entity,
-    zoo_select_with_point,
     zoo_set_selection_filter,
+    zoo_snapshot,
     zoo_snapshot_of_cad,
     zoo_snapshot_of_kcl,
     zoo_start_modeling_session,
@@ -671,43 +668,6 @@ async def entity_distance(
 
 
 @mcp.tool()
-async def select_with_point(
-    x: float,
-    y: float,
-    selection_type: SceneSelectionType,
-    kcl_code: str | None = None,
-    kcl_path: str | None = None,
-    session_id: str | None = None,
-) -> SelectWithPoint:
-    """Select a model entity at window coordinates.
-
-      Not a raycast, but "GPU picking", which uses the association of the pixel
-      to the texture to the mesh to select something.
-
-      Each selection operation modifies a "selection set".
-
-    Args:
-        x: Horizontal window coordinate.
-        y: Vertical window coordinate.
-        selection_type: Whether to replace, add to, or remove from the selection.
-        kcl_code: KCL code defining the model.
-        kcl_path: A .kcl file or project directory containing main.kcl.
-        session_id: An open modeling session to reuse instead of executing KCL again.
-
-    Returns:
-        SelectWithPoint: The selected entity.
-    """
-    logger.info("select_with_point tool called")
-    return zoo_select_with_point(
-        kcl_code=kcl_code,
-        kcl_path=kcl_path,
-        selected_at_window=Point2d(x=x, y=y),
-        selection_type=selection_type,
-        session_id=session_id,
-    )
-
-
-@mcp.tool()
 async def set_selection_filter(
     entity_types: list[EntityType],
     kcl_code: str | None = None,
@@ -989,6 +949,9 @@ async def highlight_set_entities(
 ) -> HighlightSetEntities:
     """Replace the currently highlighted entities. Does NOT modify the "selection set".
 
+    This is a purely visual command, which means a snapshot command show be followed up with
+    to see the result. It highlights edges, surfaces and bodies.
+
     Args:
         entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.
         kcl_code: KCL code defining the model.
@@ -1004,6 +967,40 @@ async def highlight_set_entities(
         kcl_path=kcl_path,
         entity_ids=entity_ids,
         session_id=session_id,
+    )
+
+
+@mcp.tool()
+async def snapshot(
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+    session_id: str | None = None,
+    max_image_dimension: int = 512,
+) -> ImageContent:
+    """Take a snapshot of a KCL model or the current modeling session.
+
+    Provide kcl_code or kcl_path to execute a model in a temporary scene. To
+    capture an existing scene without re-executing KCL, provide the session_id
+    returned by start_modeling_session. A session snapshot uses the scene's
+    current camera state.
+
+    Args:
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to capture.
+        max_image_dimension: Maximum width or height of the returned JPEG.
+
+    Returns:
+        ImageContent: A JPEG snapshot of the current scene.
+    """
+    logger.info("snapshot tool called")
+    return encode_image(
+        zoo_snapshot(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            session_id=session_id,
+            max_image_dimension=max_image_dimension,
+        )
     )
 
 

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -75,6 +75,9 @@ from zoo_mcp.zoo_tools import (
     zoo_set_selection_filter,
     zoo_snapshot_of_cad,
     zoo_snapshot_of_kcl,
+    zoo_start_modeling_session,
+    zoo_stop_all_modeling_sessions,
+    zoo_stop_modeling_session,
 )
 
 
@@ -125,6 +128,7 @@ async def _lifespan(_server: FastMCP) -> AsyncIterator[None]:
     try:
         yield
     finally:
+        zoo_stop_all_modeling_sessions()
         if _kcl_index_task is not None and not _kcl_index_task.done():
             _kcl_index_task.cancel()
         _kcl_index_task = None
@@ -415,12 +419,16 @@ async def convert_cad_file(
 async def execute_kcl(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> tuple[bool, str]:
     """Execute KCL code given a string of KCL code or a path to a KCL project. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
+
+      Does NOT return an artifact graph and can have large network overhead depending on the model.
 
     Args:
         kcl_code (str | None): The KCL code to execute.
         kcl_path (str | None): The path to a KCL file to execute. The path should point to a .kcl file or a directory containing a main.kcl file.
+        session_id: An open modeling session in which to execute the KCL.
 
     Returns:
         tuple(bool, str): Returns True if the KCL code executed successfully and a success message, False otherwise and the error message.
@@ -429,7 +437,11 @@ async def execute_kcl(
     logger.info("execute_kcl tool called")
 
     try:
-        return await zoo_execute_kcl(kcl_code=kcl_code, kcl_path=kcl_path)
+        return await zoo_execute_kcl(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            session_id=session_id,
+        )
     except Exception as e:
         return False, f"Failed to execute KCL code: {e}"
 
@@ -438,12 +450,14 @@ async def execute_kcl(
 async def exec_kcl_project(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Run a KCL project on the server side and return its artifact graph.
 
     Args:
         kcl_code (str | None): KCL code to run as a single-file project.
         kcl_path (str | None): A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session in which to execute the project.
 
     Returns:
         dict | str: The artifact graph produced by execution, or an error message.
@@ -452,9 +466,43 @@ async def exec_kcl_project(
     logger.info("exec_kcl_project tool called")
 
     try:
-        return zoo_exec_kcl_project(kcl_code=kcl_code, kcl_path=kcl_path)
+        return zoo_exec_kcl_project(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            session_id=session_id,
+        )
     except Exception as e:
         return f"Failed to execute KCL project: {e}"
+
+
+@mcp.tool()
+async def start_modeling_session() -> dict | str:
+    """Open an empty modeling websocket for subsequent tools.
+
+    Pass the returned session_id to execute_kcl or exec_kcl_project to populate
+    the scene, then reuse it with modeling query, selection, and highlight tools.
+    Stop the session explicitly with stop_modeling_session when finished.
+    """
+    logger.info("start_modeling_session tool called")
+    try:
+        return {"session_id": zoo_start_modeling_session()}
+    except Exception as e:
+        return f"Failed to start modeling session: {e}"
+
+
+@mcp.tool()
+async def stop_modeling_session(session_id: str) -> dict | str:
+    """Close a persistent modeling websocket session.
+
+    Args:
+        session_id: The ID returned by start_modeling_session.
+    """
+    logger.info("stop_modeling_session tool called")
+    try:
+        zoo_stop_modeling_session(session_id)
+        return {"stopped_session_id": session_id}
+    except Exception as e:
+        return f"Failed to stop modeling session: {e}"
 
 
 @mcp.tool()
@@ -552,6 +600,7 @@ async def get_face_info(
     face_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the position, gradient, normal, and center of a face in a KCL model.
 
@@ -559,6 +608,7 @@ async def get_face_info(
         face_id (str): Usually a user or LLM-selected face id.
         kcl_code (str | None): The KCL code defining the model.
         kcl_path (str | None): A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
         dict | str: The face position, gradient, normal, and center, or an error message.
@@ -574,6 +624,7 @@ async def get_face_info(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             face_id=Uuid(face_id),
+            session_id=session_id,
         )
         return {
             "face_get_position": face_info.face_get_position.model_dump(),
@@ -591,6 +642,7 @@ async def entity_distance(
     on_axis: GlobalAxis | None = None,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the minimum and maximum distance between two model entities.
 
@@ -600,6 +652,7 @@ async def entity_distance(
         on_axis: Optional global axis for projected distance; omit for Euclidean distance.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("entity_distance tool called")
     try:
@@ -609,6 +662,7 @@ async def entity_distance(
             entity_id1=Uuid(entity_id1),
             entity_id2=Uuid(entity_id2),
             on_axis=on_axis,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -622,6 +676,7 @@ async def select_with_point(
     selection_type: SceneSelectionType,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Select a model entity at window coordinates.
 
@@ -636,6 +691,7 @@ async def select_with_point(
         selection_type: Whether to replace, add to, or remove from the selection.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("select_with_point tool called")
     try:
@@ -644,6 +700,7 @@ async def select_with_point(
             kcl_path=kcl_path,
             selected_at_window=Point2d(x=x, y=y),
             selection_type=selection_type,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -655,6 +712,7 @@ async def set_selection_filter(
     entity_types: list[EntityType],
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Set which model entity types can be added to the "selection set".
 
@@ -662,6 +720,7 @@ async def set_selection_filter(
         entity_types: Entity types permitted by the selection filter.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("set_selection_filter tool called")
     try:
@@ -669,6 +728,7 @@ async def set_selection_filter(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_types=entity_types,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -680,6 +740,7 @@ async def select_entity(
     entities: list[EntityReference],
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Replace the current "selection set" with explicit entity references.
 
@@ -687,6 +748,7 @@ async def select_entity(
         entities: Typed face, edge, solid, segment, or other entity references.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("select_entity tool called")
     try:
@@ -694,6 +756,7 @@ async def select_entity(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entities=entities,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -705,6 +768,7 @@ async def curve_get_end_points(
     curve_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the start and end points of a curve entity.
 
@@ -712,6 +776,7 @@ async def curve_get_end_points(
         curve_id: Curve UUID, typically obtained from an artifact graph.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("curve_get_end_points tool called")
     try:
@@ -719,6 +784,7 @@ async def curve_get_end_points(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             curve_id=Uuid(curve_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -731,6 +797,7 @@ async def engine_util_evaluate_path(
     t: float,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Evaluate a serialized KCL path at parameter t.
 
@@ -775,6 +842,7 @@ async def engine_util_evaluate_path(
         t: Normalized path parameter, conventionally between 0 and 1.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("engine_util_evaluate_path tool called")
     try:
@@ -783,6 +851,7 @@ async def engine_util_evaluate_path(
             kcl_path=kcl_path,
             path_json=path_json,
             t=t,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -794,6 +863,7 @@ async def curve_get_type(
     curve_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get whether a curve is a line, arc, or NURBS curve."""
     logger.info("curve_get_type tool called")
@@ -802,6 +872,7 @@ async def curve_get_type(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             curve_id=Uuid(curve_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -813,6 +884,7 @@ async def edge_get_length(
     edge_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the length of an edge entity in the current scene units."""
     logger.info("edge_get_length tool called")
@@ -821,6 +893,7 @@ async def edge_get_length(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             edge_id=Uuid(edge_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -832,6 +905,7 @@ async def entity_get_all_child_uuids(
     entity_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get all child UUIDs belonging to an entity."""
     logger.info("entity_get_all_child_uuids tool called")
@@ -840,6 +914,7 @@ async def entity_get_all_child_uuids(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_id=Uuid(entity_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -851,6 +926,7 @@ async def entity_get_index(
     entity_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get an entity's index within its parent."""
     logger.info("entity_get_index tool called")
@@ -859,6 +935,7 @@ async def entity_get_index(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_id=Uuid(entity_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -870,6 +947,7 @@ async def entity_get_parent_id(
     entity_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the UUID of an entity's parent."""
     logger.info("entity_get_parent_id tool called")
@@ -878,6 +956,7 @@ async def entity_get_parent_id(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_id=Uuid(entity_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -889,6 +968,7 @@ async def entity_get_sketch_paths(
     entity_id: str,
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Get the sketch path UUIDs belonging to an entity."""
     logger.info("entity_get_sketch_paths tool called")
@@ -897,6 +977,7 @@ async def entity_get_sketch_paths(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_id=Uuid(entity_id),
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:
@@ -908,6 +989,7 @@ async def highlight_set_entities(
     entity_ids: list[str],
     kcl_code: str | None = None,
     kcl_path: str | None = None,
+    session_id: str | None = None,
 ) -> dict | str:
     """Replace the currently highlighted entities. Does NOT modify the "selection set".
 
@@ -915,6 +997,7 @@ async def highlight_set_entities(
         entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
+        session_id: An open modeling session to reuse instead of executing KCL again.
     """
     logger.info("highlight_set_entities tool called")
     try:
@@ -922,6 +1005,7 @@ async def highlight_set_entities(
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             entity_ids=entity_ids,
+            session_id=session_id,
         )
         return result.model_dump()
     except Exception as e:

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -611,7 +611,8 @@ async def get_face_info(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: The face position, gradient, normal, and center, or an error message.
+        dict | str: JSON serialization of FaceInfo on success, or an error message.
+                    Contains the face position, gradient, normal, and center.
                     The position is the starting point of the face's outside perimeter in KittyCAD engine space. Pretty confusing.
                     The gradient is the direction of greatest change of a scalar function.
                     The normal is a typical face normal.
@@ -653,6 +654,9 @@ async def entity_distance(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of EntityGetDistance on success, or an error message.
     """
     logger.info("entity_distance tool called")
     try:
@@ -692,6 +696,9 @@ async def select_with_point(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of SelectWithPoint on success, or an error message.
     """
     logger.info("select_with_point tool called")
     try:
@@ -721,6 +728,9 @@ async def set_selection_filter(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of SetSelectionFilter on success, or an error message.
     """
     logger.info("set_selection_filter tool called")
     try:
@@ -749,6 +759,9 @@ async def select_entity(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of SelectEntity on success, or an error message.
     """
     logger.info("select_entity tool called")
     try:
@@ -777,6 +790,9 @@ async def curve_get_end_points(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of CurveGetEndPoints on success, or an error message.
     """
     logger.info("curve_get_end_points tool called")
     try:
@@ -843,6 +859,9 @@ async def engine_util_evaluate_path(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of EngineUtilEvaluatePath on success, or an error message.
     """
     logger.info("engine_util_evaluate_path tool called")
     try:
@@ -865,7 +884,11 @@ async def curve_get_type(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get whether a curve is a line, arc, or NURBS curve."""
+    """Get whether a curve is a line, arc, or NURBS curve.
+
+    Returns:
+        dict | str: JSON serialization of CurveGetType on success, or an error message.
+    """
     logger.info("curve_get_type tool called")
     try:
         result = zoo_curve_get_type(
@@ -886,7 +909,11 @@ async def edge_get_length(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get the length of an edge entity in the current scene units."""
+    """Get the length of an edge entity in the current scene units.
+
+    Returns:
+        dict | str: JSON serialization of EdgeGetLength on success, or an error message.
+    """
     logger.info("edge_get_length tool called")
     try:
         result = zoo_edge_get_length(
@@ -907,7 +934,11 @@ async def entity_get_all_child_uuids(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get all child UUIDs belonging to an entity."""
+    """Get all child UUIDs belonging to an entity.
+
+    Returns:
+        dict | str: JSON serialization of EntityGetAllChildUuids on success, or an error message.
+    """
     logger.info("entity_get_all_child_uuids tool called")
     try:
         result = zoo_entity_get_all_child_uuids(
@@ -928,7 +959,11 @@ async def entity_get_index(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get an entity's index within its parent."""
+    """Get an entity's index within its parent.
+
+    Returns:
+        dict | str: JSON serialization of EntityGetIndex on success, or an error message.
+    """
     logger.info("entity_get_index tool called")
     try:
         result = zoo_entity_get_index(
@@ -949,7 +984,11 @@ async def entity_get_parent_id(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get the UUID of an entity's parent."""
+    """Get the UUID of an entity's parent.
+
+    Returns:
+        dict | str: JSON serialization of EntityGetParentId on success, or an error message.
+    """
     logger.info("entity_get_parent_id tool called")
     try:
         result = zoo_entity_get_parent_id(
@@ -970,7 +1009,11 @@ async def entity_get_sketch_paths(
     kcl_path: str | None = None,
     session_id: str | None = None,
 ) -> dict | str:
-    """Get the sketch path UUIDs belonging to an entity."""
+    """Get the sketch path UUIDs belonging to an entity.
+
+    Returns:
+        dict | str: JSON serialization of EntityGetSketchPaths on success, or an error message.
+    """
     logger.info("entity_get_sketch_paths tool called")
     try:
         result = zoo_entity_get_sketch_paths(
@@ -998,6 +1041,9 @@ async def highlight_set_entities(
         kcl_code: KCL code defining the model.
         kcl_path: A .kcl file or project directory containing main.kcl.
         session_id: An open modeling session to reuse instead of executing KCL again.
+
+    Returns:
+        dict | str: JSON serialization of HighlightSetEntities on success, or an error message.
     """
     logger.info("highlight_set_entities tool called")
     try:

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -1091,7 +1091,8 @@ async def snapshot(
     max_image_dimension: int = 512,
     zoom: bool = True,
     highlight_edges: bool = False,
-) -> ImageContent:
+    output_path: str | None = None,
+) -> ImageContent | str:
     """Take a snapshot of a KCL model or the current modeling session.
 
     Provide kcl_code or kcl_path to execute a model in a temporary scene. To
@@ -1111,21 +1112,24 @@ async def snapshot(
         highlight_edges: Whether rendered edges should be outlined. Default is
                          False so that entities highlighted with
                          highlight_set_entities are obvious in the image.
+        output_path (str | None): If provided, the snapshot is written to disk and the absolute file path is returned instead of the image. May be a file path (e.g. '/path/to/image.jpg') or a directory (in which case the file is named 'image.jpg'). If omitted, the image is returned inline as an ImageContent.
 
     Returns:
-        ImageContent: A JPEG snapshot of the current scene.
+        ImageContent | str: The snapshot as an inline image when output_path is
+                            omitted; otherwise the absolute path to the saved file.
     """
     logger.info("snapshot tool called")
-    return encode_image(
-        zoo_snapshot(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            session_id=session_id,
-            max_image_dimension=max_image_dimension,
-            zoom=zoom,
-            highlight_edges=highlight_edges,
-        )
+    image = zoo_snapshot(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        session_id=session_id,
+        max_image_dimension=max_image_dimension,
+        zoom=zoom,
+        highlight_edges=highlight_edges,
     )
+    if output_path is not None:
+        return save_image_bytes_to_disk(image, output_path)
+    return encode_image(image)
 
 
 @mcp.tool()

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -725,11 +725,6 @@ async def entity_distance(
     ).data
 
 
-# Selection and highlight commands mutate engine scene state, so they only make
-# sense against a session that outlives the call. Executing KCL just to set a
-# selection would discard the scene, and the selection with it.
-
-
 @mcp.tool()
 async def set_selection_filter(
     entity_types: list[EntityType],
@@ -869,9 +864,6 @@ async def highlight_set_entities(
         "highlight entities",
         session_id,
     ).data
-
-
-# Get information around curves and segments.
 
 
 @mcp.tool()
@@ -1026,9 +1018,6 @@ async def edge_get_length(
         "edge length",
         session_id,
     ).data
-
-
-# Entity relationship tools.
 
 
 @mcp.tool()

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -1090,12 +1090,14 @@ async def snapshot(
     session_id: str | None = None,
     max_image_dimension: int = 512,
     zoom: bool = True,
+    highlight_edges: bool = False,
 ) -> ImageContent:
     """Take a snapshot of a KCL model or the current modeling session.
 
     Provide kcl_code or kcl_path to execute a model in a temporary scene. To
     capture an existing scene without re-executing KCL, provide the session_id
-    returned by start_modeling_session.
+    returned by start_modeling_session. The camera always uses an orthographic
+    projection.
 
     Args:
         kcl_code: KCL code defining the model.
@@ -1106,6 +1108,9 @@ async def snapshot(
               Leave True unless you have positioned the session's camera
               yourself; a freshly executed scene is not framed, so zoom=False
               renders the model only a few pixels wide.
+        highlight_edges: Whether rendered edges should be outlined. Default is
+                         False so that entities highlighted with
+                         highlight_set_entities are obvious in the image.
 
     Returns:
         ImageContent: A JPEG snapshot of the current scene.
@@ -1118,6 +1123,7 @@ async def snapshot(
             session_id=session_id,
             max_image_dimension=max_image_dimension,
             zoom=zoom,
+            highlight_edges=highlight_edges,
         )
     )
 

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -4,11 +4,24 @@ from contextlib import asynccontextmanager
 
 import kcl
 from kittycad.models import (
+    CurveGetEndPoints,
+    CurveGetType,
+    EdgeGetLength,
+    EngineUtilEvaluatePath,
+    EntityGetAllChildUuids,
+    EntityGetDistance,
+    EntityGetIndex,
+    EntityGetParentId,
+    EntityGetSketchPaths,
     EntityReference,
     EntityType,
     GlobalAxis,
+    HighlightSetEntities,
     Point2d,
     SceneSelectionType,
+    SelectEntity,
+    SelectWithPoint,
+    SetSelectionFilter,
 )
 from kittycad.models.modeling_cmd import OptionDefaultCameraLookAt, Point3d
 from kittycad.models.uuid import Uuid
@@ -36,6 +49,7 @@ from zoo_mcp.utils.image_utils import (
 )
 from zoo_mcp.zoo_tools import (
     CameraView,
+    FaceInfo,
     zoo_calculate_bounding_box_cad,
     zoo_calculate_bounding_box_kcl,
     zoo_calculate_cad_physical_properties,
@@ -451,7 +465,7 @@ async def exec_kcl_project(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> dict[str, object]:
     """Run a KCL project on the server side and return its artifact graph.
 
     Args:
@@ -460,49 +474,46 @@ async def exec_kcl_project(
         session_id: An open modeling session in which to execute the project.
 
     Returns:
-        dict | str: The artifact graph produced by execution, or an error message.
-                    Contains UUID mappings to source code and somewhat structured understanding of the model.
+        dict[str, object]: The artifact graph produced by execution. Contains UUID
+                           mappings to source code and a somewhat structured
+                           understanding of the model.
     """
     logger.info("exec_kcl_project tool called")
 
-    try:
-        return zoo_exec_kcl_project(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            session_id=session_id,
-        )
-    except Exception as e:
-        return f"Failed to execute KCL project: {e}"
+    return zoo_exec_kcl_project(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
-async def start_modeling_session() -> dict | str:
+async def start_modeling_session() -> str:
     """Open an empty modeling websocket for subsequent tools.
 
     Pass the returned session_id to execute_kcl or exec_kcl_project to populate
     the scene, then reuse it with modeling query, selection, and highlight tools.
     Stop the session explicitly with stop_modeling_session when finished.
+
+    Returns:
+        str: The session ID to pass to session-aware modeling tools.
     """
     logger.info("start_modeling_session tool called")
-    try:
-        return {"session_id": zoo_start_modeling_session()}
-    except Exception as e:
-        return f"Failed to start modeling session: {e}"
+    return zoo_start_modeling_session()
 
 
 @mcp.tool()
-async def stop_modeling_session(session_id: str) -> dict | str:
+async def stop_modeling_session(session_id: str) -> None:
     """Close a persistent modeling websocket session.
 
     Args:
         session_id: The ID returned by start_modeling_session.
+
+    Returns:
+        None
     """
     logger.info("stop_modeling_session tool called")
-    try:
-        zoo_stop_modeling_session(session_id)
-        return {"stopped_session_id": session_id}
-    except Exception as e:
-        return f"Failed to stop modeling session: {e}"
+    zoo_stop_modeling_session(session_id)
 
 
 @mcp.tool()
@@ -601,7 +612,7 @@ async def get_face_info(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> FaceInfo:
     """Get the position, gradient, normal, and center of a face in a KCL model.
 
     Args:
@@ -611,29 +622,19 @@ async def get_face_info(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of FaceInfo on success, or an error message.
-                    Contains the face position, gradient, normal, and center.
-                    The position is the starting point of the face's outside perimeter in KittyCAD engine space. Pretty confusing.
-                    The gradient is the direction of greatest change of a scalar function.
-                    The normal is a typical face normal.
-                    The center is the geometric center of the face. *Prefer this over the position.*
+        FaceInfo: The face position, gradient, normal, and center. The position is
+                  the starting point of the face's outside perimeter in KittyCAD
+                  engine space. The center is the geometric center of the face and
+                  should generally be preferred over the position.
     """
     logger.info("get_face_info tool called for face_id=%s", face_id)
 
-    try:
-        face_info = zoo_face_info(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            face_id=Uuid(face_id),
-            session_id=session_id,
-        )
-        return {
-            "face_get_position": face_info.face_get_position.model_dump(),
-            "face_get_gradient": face_info.face_get_gradient.model_dump(),
-            "face_get_center": face_info.face_get_center.model_dump(),
-        }
-    except Exception as e:
-        return f"Failed to get face information: {e}"
+    return zoo_face_info(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        face_id=Uuid(face_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -644,7 +645,7 @@ async def entity_distance(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EntityGetDistance:
     """Get the minimum and maximum distance between two model entities.
 
     Args:
@@ -656,21 +657,17 @@ async def entity_distance(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of EntityGetDistance on success, or an error message.
+        EntityGetDistance: The minimum and maximum distance between the entities.
     """
     logger.info("entity_distance tool called")
-    try:
-        result = zoo_entity_distance(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_id1=Uuid(entity_id1),
-            entity_id2=Uuid(entity_id2),
-            on_axis=on_axis,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get entity distance: {e}"
+    return zoo_entity_distance(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_id1=Uuid(entity_id1),
+        entity_id2=Uuid(entity_id2),
+        on_axis=on_axis,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -681,7 +678,7 @@ async def select_with_point(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> SelectWithPoint:
     """Select a model entity at window coordinates.
 
       Not a raycast, but "GPU picking", which uses the association of the pixel
@@ -698,20 +695,16 @@ async def select_with_point(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of SelectWithPoint on success, or an error message.
+        SelectWithPoint: The selected entity.
     """
     logger.info("select_with_point tool called")
-    try:
-        result = zoo_select_with_point(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            selected_at_window=Point2d(x=x, y=y),
-            selection_type=selection_type,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to select with point: {e}"
+    return zoo_select_with_point(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        selected_at_window=Point2d(x=x, y=y),
+        selection_type=selection_type,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -720,7 +713,7 @@ async def set_selection_filter(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> SetSelectionFilter:
     """Set which model entity types can be added to the "selection set".
 
     Args:
@@ -730,19 +723,15 @@ async def set_selection_filter(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of SetSelectionFilter on success, or an error message.
+        SetSelectionFilter: Confirmation that the filter was set.
     """
     logger.info("set_selection_filter tool called")
-    try:
-        result = zoo_set_selection_filter(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_types=entity_types,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to set selection filter: {e}"
+    return zoo_set_selection_filter(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_types=entity_types,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -751,7 +740,7 @@ async def select_entity(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> SelectEntity:
     """Replace the current "selection set" with explicit entity references.
 
     Args:
@@ -761,19 +750,15 @@ async def select_entity(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of SelectEntity on success, or an error message.
+        SelectEntity: Confirmation that the selection was replaced.
     """
     logger.info("select_entity tool called")
-    try:
-        result = zoo_select_entity(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entities=entities,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to select entities: {e}"
+    return zoo_select_entity(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entities=entities,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -782,7 +767,7 @@ async def curve_get_end_points(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> CurveGetEndPoints:
     """Get the start and end points of a curve entity.
 
     Args:
@@ -792,19 +777,15 @@ async def curve_get_end_points(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of CurveGetEndPoints on success, or an error message.
+        CurveGetEndPoints: The curve's start and end points.
     """
     logger.info("curve_get_end_points tool called")
-    try:
-        result = zoo_curve_get_end_points(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            curve_id=Uuid(curve_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get curve endpoints: {e}"
+    return zoo_curve_get_end_points(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        curve_id=Uuid(curve_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -814,7 +795,7 @@ async def engine_util_evaluate_path(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EngineUtilEvaluatePath:
     """Evaluate a serialized KCL path at parameter t.
 
     Examples of `path_json`:
@@ -861,20 +842,16 @@ async def engine_util_evaluate_path(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of EngineUtilEvaluatePath on success, or an error message.
+        EngineUtilEvaluatePath: The position on the path at parameter t.
     """
     logger.info("engine_util_evaluate_path tool called")
-    try:
-        result = zoo_engine_util_evaluate_path(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            path_json=path_json,
-            t=t,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to evaluate path: {e}"
+    return zoo_engine_util_evaluate_path(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        path_json=path_json,
+        t=t,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -883,23 +860,19 @@ async def curve_get_type(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> CurveGetType:
     """Get whether a curve is a line, arc, or NURBS curve.
 
     Returns:
-        dict | str: JSON serialization of CurveGetType on success, or an error message.
+        CurveGetType: The curve's geometric type.
     """
     logger.info("curve_get_type tool called")
-    try:
-        result = zoo_curve_get_type(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            curve_id=Uuid(curve_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get curve type: {e}"
+    return zoo_curve_get_type(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        curve_id=Uuid(curve_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -908,23 +881,19 @@ async def edge_get_length(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EdgeGetLength:
     """Get the length of an edge entity in the current scene units.
 
     Returns:
-        dict | str: JSON serialization of EdgeGetLength on success, or an error message.
+        EdgeGetLength: The edge length in the current scene units.
     """
     logger.info("edge_get_length tool called")
-    try:
-        result = zoo_edge_get_length(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            edge_id=Uuid(edge_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get edge length: {e}"
+    return zoo_edge_get_length(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        edge_id=Uuid(edge_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -933,23 +902,19 @@ async def entity_get_all_child_uuids(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EntityGetAllChildUuids:
     """Get all child UUIDs belonging to an entity.
 
     Returns:
-        dict | str: JSON serialization of EntityGetAllChildUuids on success, or an error message.
+        EntityGetAllChildUuids: All child entity UUIDs.
     """
     logger.info("entity_get_all_child_uuids tool called")
-    try:
-        result = zoo_entity_get_all_child_uuids(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_id=Uuid(entity_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get entity child UUIDs: {e}"
+    return zoo_entity_get_all_child_uuids(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_id=Uuid(entity_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -958,23 +923,19 @@ async def entity_get_index(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EntityGetIndex:
     """Get an entity's index within its parent.
 
     Returns:
-        dict | str: JSON serialization of EntityGetIndex on success, or an error message.
+        EntityGetIndex: The entity's index within its parent.
     """
     logger.info("entity_get_index tool called")
-    try:
-        result = zoo_entity_get_index(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_id=Uuid(entity_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get entity index: {e}"
+    return zoo_entity_get_index(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_id=Uuid(entity_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -983,23 +944,19 @@ async def entity_get_parent_id(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EntityGetParentId:
     """Get the UUID of an entity's parent.
 
     Returns:
-        dict | str: JSON serialization of EntityGetParentId on success, or an error message.
+        EntityGetParentId: The parent entity's UUID.
     """
     logger.info("entity_get_parent_id tool called")
-    try:
-        result = zoo_entity_get_parent_id(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_id=Uuid(entity_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get entity parent ID: {e}"
+    return zoo_entity_get_parent_id(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_id=Uuid(entity_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -1008,23 +965,19 @@ async def entity_get_sketch_paths(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> EntityGetSketchPaths:
     """Get the sketch path UUIDs belonging to an entity.
 
     Returns:
-        dict | str: JSON serialization of EntityGetSketchPaths on success, or an error message.
+        EntityGetSketchPaths: The sketch path UUIDs belonging to the entity.
     """
     logger.info("entity_get_sketch_paths tool called")
-    try:
-        result = zoo_entity_get_sketch_paths(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_id=Uuid(entity_id),
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to get entity sketch paths: {e}"
+    return zoo_entity_get_sketch_paths(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_id=Uuid(entity_id),
+        session_id=session_id,
+    )
 
 
 @mcp.tool()
@@ -1033,7 +986,7 @@ async def highlight_set_entities(
     kcl_code: str | None = None,
     kcl_path: str | None = None,
     session_id: str | None = None,
-) -> dict | str:
+) -> HighlightSetEntities:
     """Replace the currently highlighted entities. Does NOT modify the "selection set".
 
     Args:
@@ -1043,19 +996,15 @@ async def highlight_set_entities(
         session_id: An open modeling session to reuse instead of executing KCL again.
 
     Returns:
-        dict | str: JSON serialization of HighlightSetEntities on success, or an error message.
+        HighlightSetEntities: Confirmation that the highlights were replaced.
     """
     logger.info("highlight_set_entities tool called")
-    try:
-        result = zoo_highlight_set_entities(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            entity_ids=entity_ids,
-            session_id=session_id,
-        )
-        return result.model_dump()
-    except Exception as e:
-        return f"Failed to highlight entities: {e}"
+    return zoo_highlight_set_entities(
+        kcl_code=kcl_code,
+        kcl_path=kcl_path,
+        entity_ids=entity_ids,
+        session_id=session_id,
+    )
 
 
 @mcp.tool()

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -3,6 +3,13 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import kcl
+from kittycad.models import (
+    EntityReference,
+    EntityType,
+    GlobalAxis,
+    Point2d,
+    SceneSelectionType,
+)
 from kittycad.models.modeling_cmd import OptionDefaultCameraLookAt, Point3d
 from kittycad.models.uuid import Uuid
 from mcp.server.fastmcp import FastMCP
@@ -38,12 +45,22 @@ from zoo_mcp.zoo_tools import (
     zoo_calculate_surface_area,
     zoo_calculate_volume,
     zoo_convert_cad_file,
+    zoo_curve_get_end_points,
+    zoo_curve_get_type,
+    zoo_edge_get_length,
+    zoo_engine_util_evaluate_path,
+    zoo_entity_distance,
+    zoo_entity_get_all_child_uuids,
+    zoo_entity_get_index,
+    zoo_entity_get_parent_id,
+    zoo_entity_get_sketch_paths,
     zoo_exec_kcl_project,
     zoo_execute_kcl,
     zoo_export_kcl,
     zoo_face_info,
     zoo_format_kcl,
     zoo_get_sketch_constraint_status,
+    zoo_highlight_set_entities,
     zoo_lint_and_fix_kcl,
     zoo_list_org_datasets,
     zoo_list_org_skills,
@@ -53,6 +70,9 @@ from zoo_mcp.zoo_tools import (
     zoo_multiview_snapshot_of_cad,
     zoo_multiview_snapshot_of_kcl,
     zoo_search_org_dataset_semantic,
+    zoo_select_entity,
+    zoo_select_with_point,
+    zoo_set_selection_filter,
     zoo_snapshot_of_cad,
     zoo_snapshot_of_kcl,
 )
@@ -536,7 +556,7 @@ async def get_face_info(
     """Get the position, gradient, normal, and center of a face in a KCL model.
 
     Args:
-        face_id (str): Intended to be a face id selected and sent by the user.
+        face_id (str): Usually a user or LLM-selected face id.
         kcl_code (str | None): The KCL code defining the model.
         kcl_path (str | None): A .kcl file or project directory containing main.kcl.
 
@@ -562,6 +582,350 @@ async def get_face_info(
         }
     except Exception as e:
         return f"Failed to get face information: {e}"
+
+
+@mcp.tool()
+async def entity_distance(
+    entity_id1: str,
+    entity_id2: str,
+    on_axis: GlobalAxis | None = None,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the minimum and maximum distance between two model entities.
+
+    Args:
+        entity_id1: The first entity UUID, typically obtained from an artifact graph.
+        entity_id2: The second entity UUID.
+        on_axis: Optional global axis for projected distance; omit for Euclidean distance.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("entity_distance tool called")
+    try:
+        result = zoo_entity_distance(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_id1=Uuid(entity_id1),
+            entity_id2=Uuid(entity_id2),
+            on_axis=on_axis,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get entity distance: {e}"
+
+
+@mcp.tool()
+async def select_with_point(
+    x: float,
+    y: float,
+    selection_type: SceneSelectionType,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Select a model entity at window coordinates.
+
+      Not a raycast, but "GPU picking", which uses the association of the pixel
+      to the texture to the mesh to select something.
+
+      Each selection operation modifies a "selection set".
+
+    Args:
+        x: Horizontal window coordinate.
+        y: Vertical window coordinate.
+        selection_type: Whether to replace, add to, or remove from the selection.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("select_with_point tool called")
+    try:
+        result = zoo_select_with_point(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            selected_at_window=Point2d(x=x, y=y),
+            selection_type=selection_type,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to select with point: {e}"
+
+
+@mcp.tool()
+async def set_selection_filter(
+    entity_types: list[EntityType],
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Set which model entity types can be added to the "selection set".
+
+    Args:
+        entity_types: Entity types permitted by the selection filter.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("set_selection_filter tool called")
+    try:
+        result = zoo_set_selection_filter(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_types=entity_types,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to set selection filter: {e}"
+
+
+@mcp.tool()
+async def select_entity(
+    entities: list[EntityReference],
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Replace the current "selection set" with explicit entity references.
+
+    Args:
+        entities: Typed face, edge, solid, segment, or other entity references.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("select_entity tool called")
+    try:
+        result = zoo_select_entity(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entities=entities,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to select entities: {e}"
+
+
+@mcp.tool()
+async def curve_get_end_points(
+    curve_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the start and end points of a curve entity.
+
+    Args:
+        curve_id: Curve UUID, typically obtained from an artifact graph.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("curve_get_end_points tool called")
+    try:
+        result = zoo_curve_get_end_points(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            curve_id=Uuid(curve_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get curve endpoints: {e}"
+
+
+@mcp.tool()
+async def engine_util_evaluate_path(
+    path_json: str,
+    t: float,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Evaluate a serialized KCL path at parameter t.
+
+    Examples of `path_json`:
+
+    ```json
+    {
+      "start": {
+        "from": [10, 0]
+      },
+      "value": [
+        {
+          "type": "Arc",
+          "center": [0, 0],
+          "radius": 10,
+          "angle_range": [0, 90]
+        }
+      ]
+    }
+    ```
+
+    ```json
+    {
+      "start": {
+        "from": [0, 0]
+      },
+      "value": [
+        {
+          "type": "ToPoint",
+          "to": [10, 0]
+        },
+        {
+          "type": "ToPoint",
+          "to": [10, 10]
+        }
+      ]
+    }
+    ```
+
+    Args:
+        path_json: The serialized JSON representation of the KCL sketch or path.
+        t: Normalized path parameter, conventionally between 0 and 1.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("engine_util_evaluate_path tool called")
+    try:
+        result = zoo_engine_util_evaluate_path(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            path_json=path_json,
+            t=t,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to evaluate path: {e}"
+
+
+@mcp.tool()
+async def curve_get_type(
+    curve_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get whether a curve is a line, arc, or NURBS curve."""
+    logger.info("curve_get_type tool called")
+    try:
+        result = zoo_curve_get_type(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            curve_id=Uuid(curve_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get curve type: {e}"
+
+
+@mcp.tool()
+async def edge_get_length(
+    edge_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the length of an edge entity in the current scene units."""
+    logger.info("edge_get_length tool called")
+    try:
+        result = zoo_edge_get_length(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            edge_id=Uuid(edge_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get edge length: {e}"
+
+
+@mcp.tool()
+async def entity_get_all_child_uuids(
+    entity_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get all child UUIDs belonging to an entity."""
+    logger.info("entity_get_all_child_uuids tool called")
+    try:
+        result = zoo_entity_get_all_child_uuids(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_id=Uuid(entity_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get entity child UUIDs: {e}"
+
+
+@mcp.tool()
+async def entity_get_index(
+    entity_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get an entity's index within its parent."""
+    logger.info("entity_get_index tool called")
+    try:
+        result = zoo_entity_get_index(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_id=Uuid(entity_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get entity index: {e}"
+
+
+@mcp.tool()
+async def entity_get_parent_id(
+    entity_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the UUID of an entity's parent."""
+    logger.info("entity_get_parent_id tool called")
+    try:
+        result = zoo_entity_get_parent_id(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_id=Uuid(entity_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get entity parent ID: {e}"
+
+
+@mcp.tool()
+async def entity_get_sketch_paths(
+    entity_id: str,
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Get the sketch path UUIDs belonging to an entity."""
+    logger.info("entity_get_sketch_paths tool called")
+    try:
+        result = zoo_entity_get_sketch_paths(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_id=Uuid(entity_id),
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to get entity sketch paths: {e}"
+
+
+@mcp.tool()
+async def highlight_set_entities(
+    entity_ids: list[str],
+    kcl_code: str | None = None,
+    kcl_path: str | None = None,
+) -> dict | str:
+    """Replace the currently highlighted entities. Does NOT modify the "selection set".
+
+    Args:
+        entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.
+        kcl_code: KCL code defining the model.
+        kcl_path: A .kcl file or project directory containing main.kcl.
+    """
+    logger.info("highlight_set_entities tool called")
+    try:
+        result = zoo_highlight_set_entities(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            entity_ids=entity_ids,
+        )
+        return result.model_dump()
+    except Exception as e:
+        return f"Failed to highlight entities: {e}"
 
 
 @mcp.tool()

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -949,7 +949,7 @@ async def highlight_set_entities(
 ) -> HighlightSetEntities:
     """Replace the currently highlighted entities. Does NOT modify the "selection set".
 
-    This is a purely visual command, which means a snapshot command show be followed up with
+    This is a visual command, meaning the `snapshot` tool must be followed up with
     to see the result. It highlights edges, surfaces and bodies.
 
     Args:

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -4,8 +4,10 @@ from contextlib import asynccontextmanager
 
 import kcl
 from kittycad.models import (
+    CameraMovement,
     CurveGetEndPoints,
     CurveGetType,
+    DefaultCameraCenterToSelection,
     DistanceType,
     EdgeGetLength,
     EngineUtilEvaluatePath,
@@ -14,18 +16,18 @@ from kittycad.models import (
     EntityGetIndex,
     EntityGetParentId,
     EntityGetSketchPaths,
-    EntityReference,
     EntityType,
     GlobalAxis,
     HighlightSetEntities,
     ModelingCmd,
-    SelectEntity,
+    SelectReplace,
     SetSelectionFilter,
 )
 from kittycad.models.distance_type import OptionEuclidean, OptionOnAxis
 from kittycad.models.modeling_cmd import (
     OptionCurveGetEndPoints,
     OptionCurveGetType,
+    OptionDefaultCameraCenterToSelection,
     OptionDefaultCameraLookAt,
     OptionEdgeGetLength,
     OptionEngineUtilEvaluatePath,
@@ -35,7 +37,7 @@ from kittycad.models.modeling_cmd import (
     OptionEntityGetParentId,
     OptionEntityGetSketchPaths,
     OptionHighlightSetEntities,
-    OptionSelectEntity,
+    OptionSelectReplace,
     OptionSetSelectionFilter,
     Point3d,
 )
@@ -44,6 +46,9 @@ from kittycad.models.ok_modeling_cmd_response import (
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionCurveGetType as ResponseCurveGetType,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionDefaultCameraCenterToSelection as ResponseDefaultCameraCenterToSelection,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionEdgeGetLength as ResponseEdgeGetLength,
@@ -70,7 +75,7 @@ from kittycad.models.ok_modeling_cmd_response import (
     OptionHighlightSetEntities as ResponseHighlightSetEntities,
 )
 from kittycad.models.ok_modeling_cmd_response import (
-    OptionSelectEntity as ResponseSelectEntity,
+    OptionSelectReplace as ResponseSelectReplace,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionSetSelectionFilter as ResponseSetSelectionFilter,
@@ -752,27 +757,79 @@ async def set_selection_filter(
 
 
 @mcp.tool()
-async def select_entity(
-    entities: list[EntityReference],
+async def select_entities(
+    entity_ids: list[str],
     session_id: str,
-) -> SelectEntity:
-    """Replace the current "selection set" with explicit entity references.
+) -> SelectReplace:
+    """Replace the "selection set" with the given entities.
+
+    Takes UUIDs exactly as they appear in an artifact graph, and works for faces,
+    edges, and solids alike.
+
+    Selected entities render with a distinct color tint and an outline, which is
+    considerably more obvious in a `snapshot` than the subtler brightening that
+    highlight_set_entities applies. For the strongest emphasis on a face, call
+    both this and highlight_set_entities; for an edge use just one, as selection
+    overrides the highlight. Follow with `snapshot` (passing zoom=False to keep
+    the current camera) to see the result.
 
     Args:
-        entities: Typed face, edge, solid, segment, or other entity references.
+        entity_ids: Entity UUIDs to select; pass an empty list to clear the selection.
         session_id: An open modeling session, from start_modeling_session. Required:
                     the selection is scene state and would be discarded without one.
 
     Returns:
-        SelectEntity: Confirmation that the selection was replaced.
+        SelectReplace: Confirmation that the selection was replaced.
     """
-    logger.info("select_entity tool called")
+    logger.info("select_entities tool called")
     return zoo_execute_modeling_command(
         None,
         None,
-        ModelingCmd(OptionSelectEntity(entities=entities)),
-        ResponseSelectEntity,
-        "select entity",
+        ModelingCmd(OptionSelectReplace(entities=entity_ids)),
+        ResponseSelectReplace,
+        "select entities",
+        session_id,
+    ).data
+
+
+@mcp.tool()
+async def center_camera_on_selection(
+    session_id: str,
+    move_vantage: bool = True,
+) -> DefaultCameraCenterToSelection:
+    """Point the camera at the current "selection set".
+
+    Useful for making a small selection legible, especially an edge: an edge is
+    only a pixel or two wide, so centring it helps far more than any change of
+    colour. Set the selection first with select_entities.
+
+    Centring moves the camera without re-framing the scene, so parts of the model
+    may fall outside the image. Follow with `snapshot` passing zoom=False, since
+    zoom=True re-frames the whole scene and undoes the centring.
+
+    Args:
+        session_id: An open modeling session, from start_modeling_session. Required:
+                    camera position is scene state and would be discarded without one.
+        move_vantage: Move the camera's vantage point as well as its target.
+                      True (the default) centres the selection most precisely;
+                      False re-aims the camera from where it already is.
+
+    Returns:
+        DefaultCameraCenterToSelection: Confirmation that the camera was centred.
+    """
+    logger.info("center_camera_on_selection tool called")
+    return zoo_execute_modeling_command(
+        None,
+        None,
+        ModelingCmd(
+            OptionDefaultCameraCenterToSelection(
+                camera_movement=CameraMovement.VANTAGE
+                if move_vantage
+                else CameraMovement.NONE
+            )
+        ),
+        ResponseDefaultCameraCenterToSelection,
+        "camera centering",
         session_id,
     ).data
 
@@ -787,6 +844,13 @@ async def highlight_set_entities(
     This is a visual command: follow it with the `snapshot` tool, passing the same
     session_id and zoom=False, to see the highlight without moving the camera. It
     highlights edges, surfaces and bodies.
+
+    Highlighting only brightens an entity slightly. select_entities is markedly
+    more obvious, tinting the entity and drawing an outline around it. For the
+    strongest emphasis on a face, call both; on an edge call only one, because
+    selection overrides the highlight. An edge is a pixel or two wide whichever
+    you choose, so also consider center_camera_on_selection or a larger
+    max_image_dimension to make one legible.
 
     Args:
         entity_ids: Entity UUIDs to highlight; pass an empty list to clear highlights.

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -27,7 +27,19 @@ from kittycad.exceptions import KittyCADClientError
 from kittycad.models import (
     Axis,
     AxisDirectionPair,
+    CurveGetEndPoints,
+    CurveGetType,
     Direction,
+    DistanceType,
+    EdgeGetLength,
+    EngineUtilEvaluatePath,
+    EntityGetAllChildUuids,
+    EntityGetDistance,
+    EntityGetIndex,
+    EntityGetParentId,
+    EntityGetSketchPaths,
+    EntityReference,
+    EntityType,
     FaceGetCenter,
     FaceGetGradient,
     FaceGetPosition,
@@ -38,6 +50,8 @@ from kittycad.models import (
     FileMass,
     FileSurfaceArea,
     FileVolume,
+    GlobalAxis,
+    HighlightSetEntities,
     ImageFormat,
     ImportFile,
     InputFormat3d,
@@ -46,6 +60,10 @@ from kittycad.models import (
     Point2d,
     Point3d,
     PostEffectType,
+    SceneSelectionType,
+    SelectEntity,
+    SelectWithPoint,
+    SetSelectionFilter,
     System,
     UnitArea,
     UnitDensity,
@@ -54,6 +72,7 @@ from kittycad.models import (
     UnitVolume,
     WebSocketRequest,
 )
+from kittycad.models.distance_type import OptionEuclidean, OptionOnAxis
 from kittycad.models.input_format3d import (
     OptionFbx,
     OptionGltf,
@@ -64,15 +83,55 @@ from kittycad.models.input_format3d import (
     OptionStl,
 )
 from kittycad.models.modeling_cmd import (
+    OptionCurveGetEndPoints,
+    OptionCurveGetType,
     OptionDefaultCameraLookAt,
     OptionDefaultCameraSetOrthographic,
+    OptionEdgeGetLength,
+    OptionEngineUtilEvaluatePath,
+    OptionEntityGetAllChildUuids,
+    OptionEntityGetDistance,
+    OptionEntityGetIndex,
+    OptionEntityGetParentId,
+    OptionEntityGetSketchPaths,
     OptionFaceGetCenter,
     OptionFaceGetGradient,
     OptionFaceGetPosition,
+    OptionHighlightSetEntities,
     OptionImportFiles,
+    OptionSelectEntity,
+    OptionSelectWithPoint,
+    OptionSetSelectionFilter,
     OptionTakeSnapshot,
     OptionViewIsometric,
     OptionZoomToFit,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionCurveGetEndPoints as ResponseCurveGetEndPoints,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionCurveGetType as ResponseCurveGetType,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEdgeGetLength as ResponseEdgeGetLength,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEngineUtilEvaluatePath as ResponseEngineUtilEvaluatePath,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetAllChildUuids as ResponseEntityGetAllChildUuids,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetDistance as ResponseEntityGetDistance,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetIndex as ResponseEntityGetIndex,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetParentId as ResponseEntityGetParentId,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetSketchPaths as ResponseEntityGetSketchPaths,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionFaceGetCenter as ResponseFaceGetCenter,
@@ -82,6 +141,18 @@ from kittycad.models.ok_modeling_cmd_response import (
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionFaceGetPosition as ResponseFaceGetPosition,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionHighlightSetEntities as ResponseHighlightSetEntities,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionSelectEntity as ResponseSelectEntity,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionSelectWithPoint as ResponseSelectWithPoint,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionSetSelectionFilter as ResponseSetSelectionFilter,
 )
 from kittycad.models.ok_web_socket_response_data import OptionModeling
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
@@ -2272,6 +2343,313 @@ def zoo_face_info(
             face_get_gradient=face_get_gradient,
             face_get_center=face_get_center,
         )
+
+
+_ModelingResponseT = TypeVar("_ModelingResponseT")
+
+
+def _send_modeling_command(
+    ws: WebSocketModelingCommandsWs,
+    command: ModelingCmd,
+    expected_response: type[_ModelingResponseT],
+    response_description: str,
+) -> _ModelingResponseT:
+    """Send one modeling command and return its matching typed response."""
+    command_id = ModelingCmdId(uuid4())
+    ws.send(
+        WebSocketRequest(
+            OptionModelingCmdReq(
+                cmd=command,
+                cmd_id=command_id,
+            )
+        )
+    )
+
+    while True:
+        message = ws.recv().root
+        if not isinstance(message, SuccessWebSocketResponse):
+            raise ZooMCPException(message)
+        if message.request_id != command_id:
+            continue
+
+        response = message.resp.root
+        if not isinstance(response, OptionModeling):
+            raise ZooMCPException("Received an unexpected websocket response")
+        modeling_response = response.data.modeling_response.root
+
+        if not isinstance(modeling_response, expected_response):
+            raise ZooMCPException(
+                f"Received an unexpected {response_description} response"
+            )
+        return modeling_response
+
+
+def _execute_project_modeling_command(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    command: ModelingCmd,
+    expected_response: type[_ModelingResponseT],
+    response_description: str,
+) -> _ModelingResponseT:
+    """Execute a KCL project, then run one modeling command in its session."""
+    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
+
+    with kittycad_client.modeling.modeling_commands_ws(
+        fps=30,
+        post_effect=PostEffectType.SSAO,
+        show_grid=False,
+        unlocked_framerate=False,
+        video_res_height=1024,
+        video_res_width=1024,
+        webrtc=False,
+    ) as ws:
+        _exec_kcl_project(ws, entrypoint, files)
+        return _send_modeling_command(
+            ws,
+            command,
+            expected_response,
+            response_description,
+        )
+
+
+def zoo_entity_distance(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_id1: Uuid,
+    entity_id2: Uuid,
+    on_axis: GlobalAxis | None = None,
+) -> EntityGetDistance:
+    """Get the distance between two entities in a KCL project.
+
+    When ``on_axis`` is provided, the distance is measured along that global
+    axis. Otherwise, the Euclidean distance is measured.
+    """
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(
+            OptionEntityGetDistance(
+                entity_id1=entity_id1,
+                entity_id2=entity_id2,
+                distance_type=DistanceType(
+                    OptionOnAxis(axis=on_axis)
+                    if on_axis is not None
+                    else OptionEuclidean()
+                ),
+            )
+        ),
+        ResponseEntityGetDistance,
+        "entity distance",
+    )
+    return response.data
+
+
+# Selection tools.
+
+
+def zoo_select_with_point(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    selected_at_window: Point2d,
+    selection_type: SceneSelectionType,
+) -> SelectWithPoint:
+    """Select an entity at the given window coordinates."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(
+            OptionSelectWithPoint(
+                selected_at_window=selected_at_window,
+                selection_type=selection_type,
+            )
+        ),
+        ResponseSelectWithPoint,
+        "select with point",
+    )
+    return response.data
+
+
+def zoo_set_selection_filter(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_types: list[EntityType],
+) -> SetSelectionFilter:
+    """Set which entity types can be selected in a KCL project."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
+        ResponseSetSelectionFilter,
+        "selection filter",
+    )
+    return response.data
+
+
+def zoo_select_entity(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entities: list[EntityReference],
+) -> SelectEntity:
+    """Replace the current selection with the given entities."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionSelectEntity(entities=entities)),
+        ResponseSelectEntity,
+        "select entity",
+    )
+    return response.data
+
+
+# Get information around curves and segments.
+
+
+def zoo_curve_get_end_points(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    curve_id: Uuid,
+) -> CurveGetEndPoints:
+    """Get the start and end points of a curve."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionCurveGetEndPoints(curve_id=curve_id)),
+        ResponseCurveGetEndPoints,
+        "curve endpoints",
+    )
+    return response.data
+
+
+def zoo_engine_util_evaluate_path(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    path_json: str,
+    t: float,
+) -> EngineUtilEvaluatePath:
+    """Evaluate a serialized KCL path at parameter ``t``."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
+        ResponseEngineUtilEvaluatePath,
+        "path evaluation",
+    )
+    return response.data
+
+
+def zoo_curve_get_type(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    curve_id: Uuid,
+) -> CurveGetType:
+    """Get the geometric type of a curve."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionCurveGetType(curve_id=curve_id)),
+        ResponseCurveGetType,
+        "curve type",
+    )
+    return response.data
+
+
+def zoo_edge_get_length(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    edge_id: Uuid,
+) -> EdgeGetLength:
+    """Get the length of an edge."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEdgeGetLength(edge_id=edge_id)),
+        ResponseEdgeGetLength,
+        "edge length",
+    )
+    return response.data
+
+
+# Entity relationship tools.
+
+
+def zoo_entity_get_all_child_uuids(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_id: Uuid,
+) -> EntityGetAllChildUuids:
+    """Get all child entity IDs for an entity."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetAllChildUuids(entity_id=entity_id)),
+        ResponseEntityGetAllChildUuids,
+        "entity child IDs",
+    )
+    return response.data
+
+
+def zoo_entity_get_index(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_id: Uuid,
+) -> EntityGetIndex:
+    """Get an entity's index within its parent."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetIndex(entity_id=entity_id)),
+        ResponseEntityGetIndex,
+        "entity index",
+    )
+    return response.data
+
+
+def zoo_entity_get_parent_id(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_id: Uuid,
+) -> EntityGetParentId:
+    """Get an entity's parent ID."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetParentId(entity_id=entity_id)),
+        ResponseEntityGetParentId,
+        "entity parent ID",
+    )
+    return response.data
+
+
+def zoo_entity_get_sketch_paths(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_id: Uuid,
+) -> EntityGetSketchPaths:
+    """Get the sketch path IDs belonging to an entity."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionEntityGetSketchPaths(entity_id=entity_id)),
+        ResponseEntityGetSketchPaths,
+        "entity sketch paths",
+    )
+    return response.data
+
+
+def zoo_highlight_set_entities(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    entity_ids: list[str],
+) -> HighlightSetEntities:
+    """Replace the currently highlighted entities."""
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
+        ResponseHighlightSetEntities,
+        "highlight entities",
+    )
+    return response.data
 
 
 async def zoo_snapshot_of_kcl(

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -2194,7 +2194,7 @@ def _exec_kcl_project(
     ws: WebSocketModelingCommandsWs,
     entrypoint: str,
     files: list[dict[str, str | list[int]]],
-) -> dict:
+) -> dict[str, object]:
     """Execute a KCL project through the server-side websocket protocol."""
     request_id = ModelingCmdId(uuid4())
     request = {
@@ -2265,7 +2265,6 @@ def _modeling_websocket_context() -> AbstractContextManager[
 
 
 def zoo_start_modeling_session() -> str:
-    """Open an empty persistent modeling websocket session."""
     context = _modeling_websocket_context()
     websocket = context.__enter__()
 
@@ -2280,7 +2279,6 @@ def zoo_start_modeling_session() -> str:
 
 
 def zoo_stop_modeling_session(session_id: str) -> None:
-    """Close and remove a persistent modeling websocket session."""
     with _modeling_sessions_lock:
         session = _modeling_sessions.pop(session_id, None)
     if session is None:
@@ -2337,8 +2335,7 @@ def zoo_exec_kcl_project(
     kcl_code: str | None = None,
     kcl_path: Path | str | None = None,
     session_id: str | None = None,
-) -> dict:
-    """Run a KCL project on the server side and return its artifact graph."""
+) -> dict[str, object]:
     entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
 
     if session_id is not None:
@@ -2355,7 +2352,6 @@ def zoo_face_info(
     face_id: Uuid,
     session_id: str | None = None,
 ) -> FaceInfo:
-    """Get the position, gradient, and center of a face in a KCL project."""
     with _modeling_websocket(kcl_code, kcl_path, session_id) as ws:
         cmd_id_face_get_position = ModelingCmdId(uuid4())
         ws.send(
@@ -2510,11 +2506,6 @@ def zoo_entity_distance(
     on_axis: GlobalAxis | None = None,
     session_id: str | None = None,
 ) -> EntityGetDistance:
-    """Get the distance between two entities in a KCL project.
-
-    When ``on_axis`` is provided, the distance is measured along that global
-    axis. Otherwise, the Euclidean distance is measured.
-    """
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2546,7 +2537,6 @@ def zoo_select_with_point(
     selection_type: SceneSelectionType,
     session_id: str | None = None,
 ) -> SelectWithPoint:
-    """Select an entity at the given window coordinates."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2569,7 +2559,6 @@ def zoo_set_selection_filter(
     entity_types: list[EntityType],
     session_id: str | None = None,
 ) -> SetSelectionFilter:
-    """Set which entity types can be selected in a KCL project."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2587,7 +2576,6 @@ def zoo_select_entity(
     entities: list[EntityReference],
     session_id: str | None = None,
 ) -> SelectEntity:
-    """Replace the current selection with the given entities."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2608,7 +2596,6 @@ def zoo_curve_get_end_points(
     curve_id: Uuid,
     session_id: str | None = None,
 ) -> CurveGetEndPoints:
-    """Get the start and end points of a curve."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2627,7 +2614,6 @@ def zoo_engine_util_evaluate_path(
     t: float,
     session_id: str | None = None,
 ) -> EngineUtilEvaluatePath:
-    """Evaluate a serialized KCL path at parameter ``t``."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2645,7 +2631,6 @@ def zoo_curve_get_type(
     curve_id: Uuid,
     session_id: str | None = None,
 ) -> CurveGetType:
-    """Get the geometric type of a curve."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2663,7 +2648,6 @@ def zoo_edge_get_length(
     edge_id: Uuid,
     session_id: str | None = None,
 ) -> EdgeGetLength:
-    """Get the length of an edge."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2684,7 +2668,6 @@ def zoo_entity_get_all_child_uuids(
     entity_id: Uuid,
     session_id: str | None = None,
 ) -> EntityGetAllChildUuids:
-    """Get all child entity IDs for an entity."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2702,7 +2685,6 @@ def zoo_entity_get_index(
     entity_id: Uuid,
     session_id: str | None = None,
 ) -> EntityGetIndex:
-    """Get an entity's index within its parent."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2720,7 +2702,6 @@ def zoo_entity_get_parent_id(
     entity_id: Uuid,
     session_id: str | None = None,
 ) -> EntityGetParentId:
-    """Get an entity's parent ID."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2738,7 +2719,6 @@ def zoo_entity_get_sketch_paths(
     entity_id: Uuid,
     session_id: str | None = None,
 ) -> EntityGetSketchPaths:
-    """Get the sketch path IDs belonging to an entity."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,
@@ -2756,7 +2736,6 @@ def zoo_highlight_set_entities(
     entity_ids: list[str],
     session_id: str | None = None,
 ) -> HighlightSetEntities:
-    """Replace the currently highlighted entities."""
     response = _execute_project_modeling_command(
         kcl_code,
         kcl_path,

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -2422,14 +2422,19 @@ def zoo_face_info(
 
             # Match on request_id first; see _send_modeling_command.
             request_id = getattr(message, "request_id", None)
-            if request_id is not None and request_id not in {
+            expected_ids = {
                 cmd_id_face_get_position,
                 cmd_id_face_get_gradient,
                 cmd_id_face_get_center,
-            }:
-                continue
+            }
+
             if not isinstance(message, SuccessWebSocketResponse):
-                raise ZooMCPException(_format_websocket_failure(message))
+                if request_id is None or request_id in expected_ids:
+                    raise ZooMCPException(_format_websocket_failure(message))
+                continue
+
+            if request_id not in expected_ids:
+                continue
 
             response = message.resp.root
             if not isinstance(response, OptionModeling):
@@ -2496,15 +2501,21 @@ def _send_modeling_command(
     while True:
         message = ws.recv().root
 
-        # Match on request_id before judging success: a persistent session can
-        # still hold frames for earlier commands, and failing this command on
-        # another command's error frame reports a bogus cause. A failure with no
-        # request_id is connection-level and does apply to us.
         request_id = getattr(message, "request_id", None)
-        if request_id is not None and request_id != command_id:
-            continue
+
         if not isinstance(message, SuccessWebSocketResponse):
-            raise ZooMCPException(_format_websocket_failure(message))
+            # Only raise on a failure that is actually ours. A failure carrying
+            # no request_id is connection-level so it does apply; one for
+            # another command is stale and would report a bogus cause here.
+            if request_id is None or request_id == command_id:
+                raise ZooMCPException(_format_websocket_failure(message))
+            continue
+
+        # Successes must match exactly. A persistent session also carries
+        # unsolicited informational frames (session data, ICE) with no
+        # request_id, and those are not responses to this command.
+        if request_id != command_id:
+            continue
 
         response = message.resp.root
         if not isinstance(response, OptionModeling):

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -62,9 +62,7 @@ from kittycad.models import (
     Point2d,
     Point3d,
     PostEffectType,
-    SceneSelectionType,
     SelectEntity,
-    SelectWithPoint,
     SetSelectionFilter,
     System,
     UnitArea,
@@ -102,7 +100,6 @@ from kittycad.models.modeling_cmd import (
     OptionHighlightSetEntities,
     OptionImportFiles,
     OptionSelectEntity,
-    OptionSelectWithPoint,
     OptionSetSelectionFilter,
     OptionTakeSnapshot,
     OptionViewIsometric,
@@ -151,10 +148,10 @@ from kittycad.models.ok_modeling_cmd_response import (
     OptionSelectEntity as ResponseSelectEntity,
 )
 from kittycad.models.ok_modeling_cmd_response import (
-    OptionSelectWithPoint as ResponseSelectWithPoint,
+    OptionSetSelectionFilter as ResponseSetSelectionFilter,
 )
 from kittycad.models.ok_modeling_cmd_response import (
-    OptionSetSelectionFilter as ResponseSetSelectionFilter,
+    OptionTakeSnapshot as ResponseTakeSnapshot,
 )
 from kittycad.models.ok_web_socket_response_data import OptionModeling
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
@@ -2530,29 +2527,6 @@ def zoo_entity_distance(
 # Selection tools.
 
 
-def zoo_select_with_point(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    selected_at_window: Point2d,
-    selection_type: SceneSelectionType,
-    session_id: str | None = None,
-) -> SelectWithPoint:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(
-            OptionSelectWithPoint(
-                selected_at_window=selected_at_window,
-                selection_type=selection_type,
-            )
-        ),
-        ResponseSelectWithPoint,
-        "select with point",
-        session_id,
-    )
-    return response.data
-
-
 def zoo_set_selection_filter(
     kcl_code: str | None,
     kcl_path: Path | str | None,
@@ -2745,6 +2719,23 @@ def zoo_highlight_set_entities(
         session_id,
     )
     return response.data
+
+
+def zoo_snapshot(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    session_id: str | None = None,
+    max_image_dimension: int = 512,
+) -> bytes:
+    response = _execute_project_modeling_command(
+        kcl_code,
+        kcl_path,
+        ModelingCmd(OptionTakeSnapshot(format=ImageFormat.JPEG)),
+        ResponseTakeSnapshot,
+        "snapshot",
+        session_id,
+    )
+    return resize_image(response.data.contents, max_image_dimension)
 
 
 async def zoo_snapshot_of_kcl(

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -1,9 +1,11 @@
 import io
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
 from uuid import uuid4
 
@@ -1153,6 +1155,7 @@ async def zoo_convert_cad_file(
 async def zoo_execute_kcl(
     kcl_code: str | None = None,
     kcl_path: Path | str | None = None,
+    session_id: str | None = None,
 ) -> tuple[bool, str]:
     """Execute KCL code given a string of KCL code or a path to a KCL project. Either kcl_code or kcl_path must be provided. If kcl_path is provided, it should point to a .kcl file or a directory containing a main.kcl file.
 
@@ -1168,6 +1171,15 @@ async def zoo_execute_kcl(
     _check_kcl_code_or_path(kcl_code, kcl_path)
 
     try:
+        if session_id is not None:
+            zoo_exec_kcl_project(
+                kcl_code=kcl_code,
+                kcl_path=kcl_path,
+                session_id=session_id,
+            )
+            logger.info("KCL code executed successfully in modeling session")
+            return True, "KCL code executed successfully"
+
         if kcl_code:
             outcome = await _execute_with_retries(kcl.execute_code, kcl_code)
         else:
@@ -2227,26 +2239,21 @@ def _exec_kcl_project(
         return artifact_graph
 
 
-def zoo_exec_kcl_project(
-    kcl_code: str | None = None,
-    kcl_path: Path | str | None = None,
-) -> dict:
-    """Run a KCL project on the server side and return its artifact graph."""
-    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
-
-    with kittycad_client.modeling.modeling_commands_ws(webrtc=False) as ws:
-        return _exec_kcl_project(ws, entrypoint, files)
+@dataclass
+class _ModelingSession:
+    context: AbstractContextManager[WebSocketModelingCommandsWs]
+    websocket: WebSocketModelingCommandsWs
+    lock: Lock
 
 
-def zoo_face_info(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    face_id: Uuid,
-) -> FaceInfo:
-    """Get the position, gradient, and center of a face in a KCL project."""
-    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
+_modeling_sessions: dict[str, _ModelingSession] = {}
+_modeling_sessions_lock = Lock()
 
-    with kittycad_client.modeling.modeling_commands_ws(
+
+def _modeling_websocket_context() -> AbstractContextManager[
+    WebSocketModelingCommandsWs
+]:
+    return kittycad_client.modeling.modeling_commands_ws(
         fps=30,
         post_effect=PostEffectType.SSAO,
         show_grid=False,
@@ -2254,9 +2261,102 @@ def zoo_face_info(
         video_res_height=1024,
         video_res_width=1024,
         webrtc=False,
-    ) as ws:
-        _exec_kcl_project(ws, entrypoint, files)
+    )
 
+
+def zoo_start_modeling_session() -> str:
+    """Open an empty persistent modeling websocket session."""
+    context = _modeling_websocket_context()
+    websocket = context.__enter__()
+
+    session_id = str(uuid4())
+    with _modeling_sessions_lock:
+        _modeling_sessions[session_id] = _ModelingSession(
+            context=context,
+            websocket=websocket,
+            lock=Lock(),
+        )
+    return session_id
+
+
+def zoo_stop_modeling_session(session_id: str) -> None:
+    """Close and remove a persistent modeling websocket session."""
+    with _modeling_sessions_lock:
+        session = _modeling_sessions.pop(session_id, None)
+    if session is None:
+        raise ZooMCPException(f"Unknown modeling session '{session_id}'")
+
+    with session.lock:
+        session.context.__exit__(None, None, None)
+
+
+def zoo_stop_all_modeling_sessions() -> None:
+    """Close all persistent modeling sessions, normally during server shutdown."""
+    with _modeling_sessions_lock:
+        sessions = list(_modeling_sessions.values())
+        _modeling_sessions.clear()
+
+    for session in sessions:
+        try:
+            with session.lock:
+                session.context.__exit__(None, None, None)
+        except Exception as error:
+            logger.warning("Failed to close modeling session: %s", error)
+
+
+# Allows external agents to reuse engine connections so the Zoo infrastructure
+# isn't spinning up and down engines for each command, when many times the same
+# engine scene has the same model.
+
+
+@contextmanager
+def _modeling_websocket(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    session_id: str | None,
+) -> Iterator[WebSocketModelingCommandsWs]:
+    if session_id is not None:
+        with _modeling_sessions_lock:
+            session = _modeling_sessions.get(session_id)
+            if session is None:
+                raise ZooMCPException(f"Unknown modeling session '{session_id}'")
+            session.lock.acquire()
+        try:
+            yield session.websocket
+        finally:
+            session.lock.release()
+        return
+
+    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
+    with _modeling_websocket_context() as websocket:
+        _exec_kcl_project(websocket, entrypoint, files)
+        yield websocket
+
+
+def zoo_exec_kcl_project(
+    kcl_code: str | None = None,
+    kcl_path: Path | str | None = None,
+    session_id: str | None = None,
+) -> dict:
+    """Run a KCL project on the server side and return its artifact graph."""
+    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
+
+    if session_id is not None:
+        with _modeling_websocket(None, None, session_id) as ws:
+            return _exec_kcl_project(ws, entrypoint, files)
+
+    with _modeling_websocket_context() as ws:
+        return _exec_kcl_project(ws, entrypoint, files)
+
+
+def zoo_face_info(
+    kcl_code: str | None,
+    kcl_path: Path | str | None,
+    face_id: Uuid,
+    session_id: str | None = None,
+) -> FaceInfo:
+    """Get the position, gradient, and center of a face in a KCL project."""
+    with _modeling_websocket(kcl_code, kcl_path, session_id) as ws:
         cmd_id_face_get_position = ModelingCmdId(uuid4())
         ws.send(
             WebSocketRequest(
@@ -2390,20 +2490,10 @@ def _execute_project_modeling_command(
     command: ModelingCmd,
     expected_response: type[_ModelingResponseT],
     response_description: str,
+    session_id: str | None = None,
 ) -> _ModelingResponseT:
     """Execute a KCL project, then run one modeling command in its session."""
-    entrypoint, files = _prepare_kcl_project(kcl_code, kcl_path)
-
-    with kittycad_client.modeling.modeling_commands_ws(
-        fps=30,
-        post_effect=PostEffectType.SSAO,
-        show_grid=False,
-        unlocked_framerate=False,
-        video_res_height=1024,
-        video_res_width=1024,
-        webrtc=False,
-    ) as ws:
-        _exec_kcl_project(ws, entrypoint, files)
+    with _modeling_websocket(kcl_code, kcl_path, session_id) as ws:
         return _send_modeling_command(
             ws,
             command,
@@ -2418,6 +2508,7 @@ def zoo_entity_distance(
     entity_id1: Uuid,
     entity_id2: Uuid,
     on_axis: GlobalAxis | None = None,
+    session_id: str | None = None,
 ) -> EntityGetDistance:
     """Get the distance between two entities in a KCL project.
 
@@ -2440,6 +2531,7 @@ def zoo_entity_distance(
         ),
         ResponseEntityGetDistance,
         "entity distance",
+        session_id,
     )
     return response.data
 
@@ -2452,6 +2544,7 @@ def zoo_select_with_point(
     kcl_path: Path | str | None,
     selected_at_window: Point2d,
     selection_type: SceneSelectionType,
+    session_id: str | None = None,
 ) -> SelectWithPoint:
     """Select an entity at the given window coordinates."""
     response = _execute_project_modeling_command(
@@ -2465,6 +2558,7 @@ def zoo_select_with_point(
         ),
         ResponseSelectWithPoint,
         "select with point",
+        session_id,
     )
     return response.data
 
@@ -2473,6 +2567,7 @@ def zoo_set_selection_filter(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_types: list[EntityType],
+    session_id: str | None = None,
 ) -> SetSelectionFilter:
     """Set which entity types can be selected in a KCL project."""
     response = _execute_project_modeling_command(
@@ -2481,6 +2576,7 @@ def zoo_set_selection_filter(
         ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
         ResponseSetSelectionFilter,
         "selection filter",
+        session_id,
     )
     return response.data
 
@@ -2489,6 +2585,7 @@ def zoo_select_entity(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entities: list[EntityReference],
+    session_id: str | None = None,
 ) -> SelectEntity:
     """Replace the current selection with the given entities."""
     response = _execute_project_modeling_command(
@@ -2497,6 +2594,7 @@ def zoo_select_entity(
         ModelingCmd(OptionSelectEntity(entities=entities)),
         ResponseSelectEntity,
         "select entity",
+        session_id,
     )
     return response.data
 
@@ -2508,6 +2606,7 @@ def zoo_curve_get_end_points(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     curve_id: Uuid,
+    session_id: str | None = None,
 ) -> CurveGetEndPoints:
     """Get the start and end points of a curve."""
     response = _execute_project_modeling_command(
@@ -2516,6 +2615,7 @@ def zoo_curve_get_end_points(
         ModelingCmd(OptionCurveGetEndPoints(curve_id=curve_id)),
         ResponseCurveGetEndPoints,
         "curve endpoints",
+        session_id,
     )
     return response.data
 
@@ -2525,6 +2625,7 @@ def zoo_engine_util_evaluate_path(
     kcl_path: Path | str | None,
     path_json: str,
     t: float,
+    session_id: str | None = None,
 ) -> EngineUtilEvaluatePath:
     """Evaluate a serialized KCL path at parameter ``t``."""
     response = _execute_project_modeling_command(
@@ -2533,6 +2634,7 @@ def zoo_engine_util_evaluate_path(
         ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
         ResponseEngineUtilEvaluatePath,
         "path evaluation",
+        session_id,
     )
     return response.data
 
@@ -2541,6 +2643,7 @@ def zoo_curve_get_type(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     curve_id: Uuid,
+    session_id: str | None = None,
 ) -> CurveGetType:
     """Get the geometric type of a curve."""
     response = _execute_project_modeling_command(
@@ -2549,6 +2652,7 @@ def zoo_curve_get_type(
         ModelingCmd(OptionCurveGetType(curve_id=curve_id)),
         ResponseCurveGetType,
         "curve type",
+        session_id,
     )
     return response.data
 
@@ -2557,6 +2661,7 @@ def zoo_edge_get_length(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     edge_id: Uuid,
+    session_id: str | None = None,
 ) -> EdgeGetLength:
     """Get the length of an edge."""
     response = _execute_project_modeling_command(
@@ -2565,6 +2670,7 @@ def zoo_edge_get_length(
         ModelingCmd(OptionEdgeGetLength(edge_id=edge_id)),
         ResponseEdgeGetLength,
         "edge length",
+        session_id,
     )
     return response.data
 
@@ -2576,6 +2682,7 @@ def zoo_entity_get_all_child_uuids(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_id: Uuid,
+    session_id: str | None = None,
 ) -> EntityGetAllChildUuids:
     """Get all child entity IDs for an entity."""
     response = _execute_project_modeling_command(
@@ -2584,6 +2691,7 @@ def zoo_entity_get_all_child_uuids(
         ModelingCmd(OptionEntityGetAllChildUuids(entity_id=entity_id)),
         ResponseEntityGetAllChildUuids,
         "entity child IDs",
+        session_id,
     )
     return response.data
 
@@ -2592,6 +2700,7 @@ def zoo_entity_get_index(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_id: Uuid,
+    session_id: str | None = None,
 ) -> EntityGetIndex:
     """Get an entity's index within its parent."""
     response = _execute_project_modeling_command(
@@ -2600,6 +2709,7 @@ def zoo_entity_get_index(
         ModelingCmd(OptionEntityGetIndex(entity_id=entity_id)),
         ResponseEntityGetIndex,
         "entity index",
+        session_id,
     )
     return response.data
 
@@ -2608,6 +2718,7 @@ def zoo_entity_get_parent_id(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_id: Uuid,
+    session_id: str | None = None,
 ) -> EntityGetParentId:
     """Get an entity's parent ID."""
     response = _execute_project_modeling_command(
@@ -2616,6 +2727,7 @@ def zoo_entity_get_parent_id(
         ModelingCmd(OptionEntityGetParentId(entity_id=entity_id)),
         ResponseEntityGetParentId,
         "entity parent ID",
+        session_id,
     )
     return response.data
 
@@ -2624,6 +2736,7 @@ def zoo_entity_get_sketch_paths(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_id: Uuid,
+    session_id: str | None = None,
 ) -> EntityGetSketchPaths:
     """Get the sketch path IDs belonging to an entity."""
     response = _execute_project_modeling_command(
@@ -2632,6 +2745,7 @@ def zoo_entity_get_sketch_paths(
         ModelingCmd(OptionEntityGetSketchPaths(entity_id=entity_id)),
         ResponseEntityGetSketchPaths,
         "entity sketch paths",
+        session_id,
     )
     return response.data
 
@@ -2640,6 +2754,7 @@ def zoo_highlight_set_entities(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     entity_ids: list[str],
+    session_id: str | None = None,
 ) -> HighlightSetEntities:
     """Replace the currently highlighted entities."""
     response = _execute_project_modeling_command(
@@ -2648,6 +2763,7 @@ def zoo_highlight_set_entities(
         ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
         ResponseHighlightSetEntities,
         "highlight entities",
+        session_id,
     )
     return response.data
 

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from threading import Lock
+from time import monotonic
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
 from uuid import uuid4
 
@@ -29,19 +30,7 @@ from kittycad.exceptions import KittyCADClientError
 from kittycad.models import (
     Axis,
     AxisDirectionPair,
-    CurveGetEndPoints,
-    CurveGetType,
     Direction,
-    DistanceType,
-    EdgeGetLength,
-    EngineUtilEvaluatePath,
-    EntityGetAllChildUuids,
-    EntityGetDistance,
-    EntityGetIndex,
-    EntityGetParentId,
-    EntityGetSketchPaths,
-    EntityReference,
-    EntityType,
     FaceGetCenter,
     FaceGetGradient,
     FaceGetPosition,
@@ -52,8 +41,6 @@ from kittycad.models import (
     FileMass,
     FileSurfaceArea,
     FileVolume,
-    GlobalAxis,
-    HighlightSetEntities,
     ImageFormat,
     ImportFile,
     InputFormat3d,
@@ -62,8 +49,6 @@ from kittycad.models import (
     Point2d,
     Point3d,
     PostEffectType,
-    SelectEntity,
-    SetSelectionFilter,
     System,
     UnitArea,
     UnitDensity,
@@ -72,7 +57,6 @@ from kittycad.models import (
     UnitVolume,
     WebSocketRequest,
 )
-from kittycad.models.distance_type import OptionEuclidean, OptionOnAxis
 from kittycad.models.input_format3d import (
     OptionFbx,
     OptionGltf,
@@ -83,54 +67,15 @@ from kittycad.models.input_format3d import (
     OptionStl,
 )
 from kittycad.models.modeling_cmd import (
-    OptionCurveGetEndPoints,
-    OptionCurveGetType,
     OptionDefaultCameraLookAt,
     OptionDefaultCameraSetOrthographic,
-    OptionEdgeGetLength,
-    OptionEngineUtilEvaluatePath,
-    OptionEntityGetAllChildUuids,
-    OptionEntityGetDistance,
-    OptionEntityGetIndex,
-    OptionEntityGetParentId,
-    OptionEntityGetSketchPaths,
     OptionFaceGetCenter,
     OptionFaceGetGradient,
     OptionFaceGetPosition,
-    OptionHighlightSetEntities,
     OptionImportFiles,
-    OptionSelectEntity,
-    OptionSetSelectionFilter,
     OptionTakeSnapshot,
     OptionViewIsometric,
     OptionZoomToFit,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionCurveGetEndPoints as ResponseCurveGetEndPoints,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionCurveGetType as ResponseCurveGetType,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEdgeGetLength as ResponseEdgeGetLength,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEngineUtilEvaluatePath as ResponseEngineUtilEvaluatePath,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEntityGetAllChildUuids as ResponseEntityGetAllChildUuids,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEntityGetDistance as ResponseEntityGetDistance,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEntityGetIndex as ResponseEntityGetIndex,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEntityGetParentId as ResponseEntityGetParentId,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionEntityGetSketchPaths as ResponseEntityGetSketchPaths,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionFaceGetCenter as ResponseFaceGetCenter,
@@ -142,21 +87,19 @@ from kittycad.models.ok_modeling_cmd_response import (
     OptionFaceGetPosition as ResponseFaceGetPosition,
 )
 from kittycad.models.ok_modeling_cmd_response import (
-    OptionHighlightSetEntities as ResponseHighlightSetEntities,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionSelectEntity as ResponseSelectEntity,
-)
-from kittycad.models.ok_modeling_cmd_response import (
-    OptionSetSelectionFilter as ResponseSetSelectionFilter,
-)
-from kittycad.models.ok_modeling_cmd_response import (
     OptionTakeSnapshot as ResponseTakeSnapshot,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionViewIsometric as ResponseViewIsometric,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionZoomToFit as ResponseZoomToFit,
 )
 from kittycad.models.ok_web_socket_response_data import OptionModeling
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
 from kittycad.models.uuid import Uuid
 from kittycad.models.web_socket_request import OptionModelingCmdReq
+from websockets.exceptions import WebSocketException
 
 from zoo_mcp import ZooMCPException, kittycad_client, logger
 from zoo_mcp.utils.image_utils import create_image_collage, resize_image
@@ -1161,7 +1104,7 @@ async def zoo_execute_kcl(
         kcl_path (Path | str | None): KCL path, the path should point to a .kcl file or a directory containing a main.kcl file.
 
     Returns:
-        tuple(bool, str): Returns True if the KCL code ran to completion and a result message, False otherwise and the error message. When the run completes, it may still report compilation issues (warnings, errors, and fatal issues, e.g. a CSG operation with no overlap); these are appended to the message rather than treated as a hard failure.
+        tuple(bool, str): Returns True if the KCL code ran to completion and a result message, False otherwise and the error message. When the run completes, it may still report compilation issues (warnings, errors, and fatal issues, e.g. a CSG operation with no overlap); these are appended to the message rather than treated as a hard failure. Note that session_id runs are executed by the engine, whose response carries no non-fatal diagnostics, so the message says so instead of implying the code is clean.
     """
     logger.info("Executing KCL code")
 
@@ -1174,8 +1117,16 @@ async def zoo_execute_kcl(
                 kcl_path=kcl_path,
                 session_id=session_id,
             )
-            logger.info("KCL code executed successfully in modeling session")
-            return True, "KCL code executed successfully"
+            logger.info("KCL code executed in modeling session")
+            # The engine's exec_kcl_project response carries only an artifact
+            # graph, so warnings the local compiler would surface are not
+            # available here. Say so rather than report an unqualified success.
+            return True, (
+                "KCL code executed successfully in the modeling session. "
+                "Non-fatal diagnostics (warnings and non-fatal errors) are not "
+                "reported for session runs; re-run without session_id to check "
+                "them."
+            )
 
         if kcl_code:
             outcome = await _execute_with_retries(kcl.execute_code, kcl_code)
@@ -2204,9 +2155,13 @@ def _exec_kcl_project(
     }
     ws.ws.send(json.dumps(request))
 
+    # Mirrors the timeout the SDK's own typed recv() applies; reading the raw
+    # socket without one hangs the caller forever if the engine drops the reply.
+    recv_timeout = getattr(ws, "_recv_timeout", 60.0)
+
     # This response is not represented in the generated SDK yet.
     while True:
-        raw_response = ws.ws.recv()
+        raw_response = ws.ws.recv(timeout=recv_timeout)
         try:
             response = json.loads(raw_response)
         except (TypeError, json.JSONDecodeError):
@@ -2241,10 +2196,19 @@ class _ModelingSession:
     context: AbstractContextManager[WebSocketModelingCommandsWs]
     websocket: WebSocketModelingCommandsWs
     lock: Lock
+    last_used: float
 
 
 _modeling_sessions: dict[str, _ModelingSession] = {}
 _modeling_sessions_lock = Lock()
+
+# The engine drops idle connections on its own, so an entry older than this is
+# assumed dead and is reaped rather than handed back to a caller.
+_MODELING_SESSION_IDLE_TIMEOUT = 600.0
+
+# A cap so a client that never calls stop_modeling_session cannot pin an
+# unbounded number of engine instances.
+_MAX_MODELING_SESSIONS = 8
 
 
 def _modeling_websocket_context() -> AbstractContextManager[
@@ -2261,7 +2225,47 @@ def _modeling_websocket_context() -> AbstractContextManager[
     )
 
 
+def _close_modeling_session(session: _ModelingSession) -> None:
+    """Close one session's websocket, waiting for any in-flight command."""
+    with session.lock:
+        session.context.__exit__(None, None, None)
+
+
+def _reap_idle_modeling_sessions() -> list[_ModelingSession]:
+    """Remove sessions idle long enough that the engine has likely dropped them.
+
+    The caller must hold ``_modeling_sessions_lock``. Returns the evicted
+    sessions so they can be closed without holding the registry lock.
+    """
+    cutoff = monotonic() - _MODELING_SESSION_IDLE_TIMEOUT
+    expired = [
+        session_id
+        for session_id, session in _modeling_sessions.items()
+        if session.last_used < cutoff
+    ]
+    evicted = []
+    for session_id in expired:
+        logger.info("Reaping idle modeling session %s", session_id)
+        evicted.append(_modeling_sessions.pop(session_id))
+    return evicted
+
+
 def zoo_start_modeling_session() -> str:
+    with _modeling_sessions_lock:
+        evicted = _reap_idle_modeling_sessions()
+        active = len(_modeling_sessions)
+    for session in evicted:
+        try:
+            _close_modeling_session(session)
+        except Exception as error:
+            logger.warning("Failed to close idle modeling session: %s", error)
+
+    if active >= _MAX_MODELING_SESSIONS:
+        raise ZooMCPException(
+            f"Too many open modeling sessions ({active}); "
+            "call stop_modeling_session on a session you no longer need"
+        )
+
     context = _modeling_websocket_context()
     websocket = context.__enter__()
 
@@ -2271,6 +2275,7 @@ def zoo_start_modeling_session() -> str:
             context=context,
             websocket=websocket,
             lock=Lock(),
+            last_used=monotonic(),
         )
     return session_id
 
@@ -2281,8 +2286,7 @@ def zoo_stop_modeling_session(session_id: str) -> None:
     if session is None:
         raise ZooMCPException(f"Unknown modeling session '{session_id}'")
 
-    with session.lock:
-        session.context.__exit__(None, None, None)
+    _close_modeling_session(session)
 
 
 def zoo_stop_all_modeling_sessions() -> None:
@@ -2293,10 +2297,15 @@ def zoo_stop_all_modeling_sessions() -> None:
 
     for session in sessions:
         try:
-            with session.lock:
-                session.context.__exit__(None, None, None)
+            _close_modeling_session(session)
         except Exception as error:
             logger.warning("Failed to close modeling session: %s", error)
+
+
+def _evict_modeling_session(session_id: str) -> None:
+    """Drop a session whose websocket is no longer usable."""
+    with _modeling_sessions_lock:
+        _modeling_sessions.pop(session_id, None)
 
 
 # Allows external agents to reuse engine connections so the Zoo infrastructure
@@ -2315,10 +2324,20 @@ def _modeling_websocket(
             session = _modeling_sessions.get(session_id)
             if session is None:
                 raise ZooMCPException(f"Unknown modeling session '{session_id}'")
-            session.lock.acquire()
+
+        # Acquired outside the registry lock: blocking on a busy session while
+        # holding it would stall every other session's management calls.
+        session.lock.acquire()
         try:
             yield session.websocket
+        except (WebSocketException, OSError) as error:
+            _evict_modeling_session(session_id)
+            raise ZooMCPException(
+                f"Modeling session '{session_id}' is no longer connected "
+                f"({error}); start a new session"
+            ) from error
         finally:
+            session.last_used = monotonic()
             session.lock.release()
         return
 
@@ -2400,14 +2419,17 @@ def zoo_face_info(
             or face_get_center is False
         ):
             message = ws.recv().root
-            if not isinstance(message, SuccessWebSocketResponse):
-                raise ZooMCPException(message)
-            if message.request_id not in {
+
+            # Match on request_id first; see _send_modeling_command.
+            request_id = getattr(message, "request_id", None)
+            if request_id is not None and request_id not in {
                 cmd_id_face_get_position,
                 cmd_id_face_get_gradient,
                 cmd_id_face_get_center,
             }:
                 continue
+            if not isinstance(message, SuccessWebSocketResponse):
+                raise ZooMCPException(_format_websocket_failure(message))
 
             response = message.resp.root
             if not isinstance(response, OptionModeling):
@@ -2441,6 +2463,19 @@ def zoo_face_info(
 _ModelingResponseT = TypeVar("_ModelingResponseT")
 
 
+def _format_websocket_failure(message: object) -> str:
+    """Render an engine failure frame as a readable message, not a model repr."""
+    errors = getattr(message, "errors", None)
+    if not errors:
+        return f"The modeling engine reported a failure: {message}"
+
+    rendered = "; ".join(
+        f"{getattr(error, 'error_code', 'error')}: {getattr(error, 'message', error)}"
+        for error in errors
+    )
+    return f"The modeling engine reported a failure: {rendered}"
+
+
 def _send_modeling_command(
     ws: WebSocketModelingCommandsWs,
     command: ModelingCmd,
@@ -2460,10 +2495,16 @@ def _send_modeling_command(
 
     while True:
         message = ws.recv().root
-        if not isinstance(message, SuccessWebSocketResponse):
-            raise ZooMCPException(message)
-        if message.request_id != command_id:
+
+        # Match on request_id before judging success: a persistent session can
+        # still hold frames for earlier commands, and failing this command on
+        # another command's error frame reports a bogus cause. A failure with no
+        # request_id is connection-level and does apply to us.
+        request_id = getattr(message, "request_id", None)
+        if request_id is not None and request_id != command_id:
             continue
+        if not isinstance(message, SuccessWebSocketResponse):
+            raise ZooMCPException(_format_websocket_failure(message))
 
         response = message.resp.root
         if not isinstance(response, OptionModeling):
@@ -2477,7 +2518,7 @@ def _send_modeling_command(
         return modeling_response
 
 
-def _execute_project_modeling_command(
+def zoo_execute_modeling_command(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     command: ModelingCmd,
@@ -2495,246 +2536,41 @@ def _execute_project_modeling_command(
         )
 
 
-def zoo_entity_distance(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_id1: Uuid,
-    entity_id2: Uuid,
-    on_axis: GlobalAxis | None = None,
-    session_id: str | None = None,
-) -> EntityGetDistance:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(
-            OptionEntityGetDistance(
-                entity_id1=entity_id1,
-                entity_id2=entity_id2,
-                distance_type=DistanceType(
-                    OptionOnAxis(axis=on_axis)
-                    if on_axis is not None
-                    else OptionEuclidean()
-                ),
-            )
-        ),
-        ResponseEntityGetDistance,
-        "entity distance",
-        session_id,
-    )
-    return response.data
-
-
-# Selection tools.
-
-
-def zoo_set_selection_filter(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_types: list[EntityType],
-    session_id: str | None = None,
-) -> SetSelectionFilter:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
-        ResponseSetSelectionFilter,
-        "selection filter",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_select_entity(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entities: list[EntityReference],
-    session_id: str | None = None,
-) -> SelectEntity:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionSelectEntity(entities=entities)),
-        ResponseSelectEntity,
-        "select entity",
-        session_id,
-    )
-    return response.data
-
-
-# Get information around curves and segments.
-
-
-def zoo_curve_get_end_points(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    curve_id: Uuid,
-    session_id: str | None = None,
-) -> CurveGetEndPoints:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionCurveGetEndPoints(curve_id=curve_id)),
-        ResponseCurveGetEndPoints,
-        "curve endpoints",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_engine_util_evaluate_path(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    path_json: str,
-    t: float,
-    session_id: str | None = None,
-) -> EngineUtilEvaluatePath:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
-        ResponseEngineUtilEvaluatePath,
-        "path evaluation",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_curve_get_type(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    curve_id: Uuid,
-    session_id: str | None = None,
-) -> CurveGetType:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionCurveGetType(curve_id=curve_id)),
-        ResponseCurveGetType,
-        "curve type",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_edge_get_length(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    edge_id: Uuid,
-    session_id: str | None = None,
-) -> EdgeGetLength:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEdgeGetLength(edge_id=edge_id)),
-        ResponseEdgeGetLength,
-        "edge length",
-        session_id,
-    )
-    return response.data
-
-
-# Entity relationship tools.
-
-
-def zoo_entity_get_all_child_uuids(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_id: Uuid,
-    session_id: str | None = None,
-) -> EntityGetAllChildUuids:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEntityGetAllChildUuids(entity_id=entity_id)),
-        ResponseEntityGetAllChildUuids,
-        "entity child IDs",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_entity_get_index(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_id: Uuid,
-    session_id: str | None = None,
-) -> EntityGetIndex:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEntityGetIndex(entity_id=entity_id)),
-        ResponseEntityGetIndex,
-        "entity index",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_entity_get_parent_id(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_id: Uuid,
-    session_id: str | None = None,
-) -> EntityGetParentId:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEntityGetParentId(entity_id=entity_id)),
-        ResponseEntityGetParentId,
-        "entity parent ID",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_entity_get_sketch_paths(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_id: Uuid,
-    session_id: str | None = None,
-) -> EntityGetSketchPaths:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionEntityGetSketchPaths(entity_id=entity_id)),
-        ResponseEntityGetSketchPaths,
-        "entity sketch paths",
-        session_id,
-    )
-    return response.data
-
-
-def zoo_highlight_set_entities(
-    kcl_code: str | None,
-    kcl_path: Path | str | None,
-    entity_ids: list[str],
-    session_id: str | None = None,
-) -> HighlightSetEntities:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
-        ResponseHighlightSetEntities,
-        "highlight entities",
-        session_id,
-    )
-    return response.data
-
-
 def zoo_snapshot(
     kcl_code: str | None,
     kcl_path: Path | str | None,
     session_id: str | None = None,
     max_image_dimension: int = 512,
+    zoom: bool = True,
 ) -> bytes:
-    response = _execute_project_modeling_command(
-        kcl_code,
-        kcl_path,
-        ModelingCmd(OptionTakeSnapshot(format=ImageFormat.JPEG)),
-        ResponseTakeSnapshot,
-        "snapshot",
-        session_id,
-    )
+    """Capture the current scene as a JPEG.
+
+    Unless ``zoom`` is False the camera is pointed isometrically and zoomed to
+    fit first; a raw take_snapshot uses whatever camera the scene happens to
+    have, which on a freshly executed project leaves the model a few pixels
+    wide.
+    """
+    with _modeling_websocket(kcl_code, kcl_path, session_id) as ws:
+        if zoom:
+            _send_modeling_command(
+                ws,
+                ModelingCmd(OptionViewIsometric()),
+                ResponseViewIsometric,
+                "isometric view",
+            )
+            _send_modeling_command(
+                ws,
+                ModelingCmd(OptionZoomToFit(padding=0.1)),
+                ResponseZoomToFit,
+                "zoom to fit",
+            )
+
+        response = _send_modeling_command(
+            ws,
+            ModelingCmd(OptionTakeSnapshot(format=ImageFormat.JPEG)),
+            ResponseTakeSnapshot,
+            "snapshot",
+        )
     return resize_image(response.data.contents, max_image_dimension)
 
 
@@ -2816,6 +2652,7 @@ def _list_org_datasets_raw() -> list[dict[str, str | None]]:
     client = kittycad_client.get_http_client()
     url = f"{kittycad_client.base_url}/org/datasets"
     page_token: str | None = None
+    seen_page_tokens: set[str] = set()
     datasets: list[dict[str, str | None]] = []
 
     while True:
@@ -2855,6 +2692,21 @@ def _list_org_datasets_raw() -> list[dict[str, str | None]]:
         page_token = payload.get("next_page")
         if not isinstance(page_token, str) or not page_token:
             return datasets
+        if page_token in seen_page_tokens:
+            logger.warning(
+                "Org datasets pagination repeated page token; stopping early"
+            )
+            return datasets
+        seen_page_tokens.add(page_token)
+
+
+def _org_datasets_empty_or_raise(
+    exc: KittyCADClientError,
+) -> list[dict[str, str | None]]:
+    """Treat a missing datasets endpoint as empty; re-raise anything else."""
+    if exc.status_code == 404:
+        return []
+    raise ZooMCPException(f"Failed to list org datasets: {exc}") from exc
 
 
 def zoo_list_org_datasets() -> list[dict[str, str | None]]:
@@ -2865,6 +2717,8 @@ def zoo_list_org_datasets() -> list[dict[str, str | None]]:
         entries, possibly empty.
     """
     logger.info("Listing org datasets")
+    use_raw_fallback = False
+    datasets = []
     try:
         datasets = list(
             kittycad_client.orgs.list_org_datasets(limit=None, page_token=None)
@@ -2874,11 +2728,17 @@ def zoo_list_org_datasets() -> list[dict[str, str | None]]:
             "SDK could not validate org datasets; falling back to raw JSON: %s",
             exc,
         )
-        return _list_org_datasets_raw()
+        use_raw_fallback = True
     except KittyCADClientError as exc:
-        if exc.status_code == 404:
-            return []
-        raise ZooMCPException(f"Failed to list org datasets: {exc}") from exc
+        return _org_datasets_empty_or_raise(exc)
+
+    # Run the fallback outside the handler above so its own client errors still
+    # get the 404-means-empty treatment instead of escaping uncaught.
+    if use_raw_fallback:
+        try:
+            return _list_org_datasets_raw()
+        except KittyCADClientError as exc:
+            return _org_datasets_empty_or_raise(exc)
 
     return [
         {"id": str(d.id), "name": d.name, "description": d.description}

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -2841,6 +2841,52 @@ async def zoo_snapshot_of_kcl(
     return resize_image(jpeg_contents_list[0], max_image_dimension)
 
 
+def _list_org_datasets_raw() -> list[dict[str, str | None]]:
+    """List datasets without validating fields unrelated to this tool's output."""
+    client = kittycad_client.get_http_client()
+    url = f"{kittycad_client.base_url}/org/datasets"
+    page_token: str | None = None
+    datasets: list[dict[str, str | None]] = []
+
+    while True:
+        params = {"page_token": page_token} if page_token is not None else None
+        response = client.get(
+            url=url,
+            headers=kittycad_client.get_headers(),
+            params=params,
+        )
+        if not response.is_success:
+            from kittycad.response_helpers import raise_for_status
+
+            raise_for_status(response)
+
+        payload = response.json()
+        items = payload.get("items", [])
+        if not isinstance(items, list):
+            raise ZooMCPException("Failed to list org datasets: invalid response")
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            dataset_id = item.get("id")
+            name = item.get("name")
+            description = item.get("description")
+            if isinstance(dataset_id, str) and isinstance(name, str):
+                datasets.append(
+                    {
+                        "id": dataset_id,
+                        "name": name,
+                        "description": description
+                        if isinstance(description, str)
+                        else None,
+                    }
+                )
+
+        page_token = payload.get("next_page")
+        if not isinstance(page_token, str) or not page_token:
+            return datasets
+
+
 def zoo_list_org_datasets() -> list[dict[str, str | None]]:
     """List all datasets visible to the org tied to the current ZOO_API_TOKEN.
 
@@ -2853,6 +2899,12 @@ def zoo_list_org_datasets() -> list[dict[str, str | None]]:
         datasets = list(
             kittycad_client.orgs.list_org_datasets(limit=None, page_token=None)
         )
+    except ValueError as exc:
+        logger.warning(
+            "SDK could not validate org datasets; falling back to raw JSON: %s",
+            exc,
+        )
+        return _list_org_datasets_raw()
     except KittyCADClientError as exc:
         if exc.status_code == 404:
             return []

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -69,6 +69,7 @@ from kittycad.models.input_format3d import (
 from kittycad.models.modeling_cmd import (
     OptionDefaultCameraLookAt,
     OptionDefaultCameraSetOrthographic,
+    OptionEdgeLinesVisible,
     OptionFaceGetCenter,
     OptionFaceGetGradient,
     OptionFaceGetPosition,
@@ -76,6 +77,12 @@ from kittycad.models.modeling_cmd import (
     OptionTakeSnapshot,
     OptionViewIsometric,
     OptionZoomToFit,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionDefaultCameraSetOrthographic as ResponseDefaultCameraSetOrthographic,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEdgeLinesVisible as ResponseEdgeLinesVisible,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OptionFaceGetCenter as ResponseFaceGetCenter,
@@ -2553,15 +2560,28 @@ def zoo_snapshot(
     session_id: str | None = None,
     max_image_dimension: int = 512,
     zoom: bool = True,
+    highlight_edges: bool = False,
 ) -> bytes:
     """Capture the current scene as a JPEG.
 
-    Unless ``zoom`` is False the camera is pointed isometrically and zoomed to
-    fit first; a raw take_snapshot uses whatever camera the scene happens to
-    have, which on a freshly executed project leaves the model a few pixels
-    wide.
+    The camera is always switched to an orthographic projection, matching the
+    other snapshot tools. Unless ``zoom`` is False the camera is also pointed
+    isometrically and zoomed to fit; a raw take_snapshot uses whatever camera
+    the scene happens to have, which on a freshly executed project leaves the
+    model a few pixels wide.
+
+    Edge lines are hidden unless ``highlight_edges`` is True, so that entities
+    highlighted via highlight_set_entities stand out instead of competing with
+    the outline drawn on every edge in the scene.
     """
     with _modeling_websocket(kcl_code, kcl_path, session_id) as ws:
+        _send_modeling_command(
+            ws,
+            ModelingCmd(OptionDefaultCameraSetOrthographic()),
+            ResponseDefaultCameraSetOrthographic,
+            "orthographic camera",
+        )
+
         if zoom:
             _send_modeling_command(
                 ws,
@@ -2575,6 +2595,13 @@ def zoo_snapshot(
                 ResponseZoomToFit,
                 "zoom to fit",
             )
+
+        _send_modeling_command(
+            ws,
+            ModelingCmd(OptionEdgeLinesVisible(hidden=not highlight_edges)),
+            ResponseEdgeLinesVisible,
+            "edge line visibility",
+        )
 
         response = _send_modeling_command(
             ws,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,26 @@ from pathlib import Path
 
 import pytest
 
+# Modules whose tests open engine websockets. Concurrent engine connections make
+# the engine drop sockets (surfacing as "received 1005"), so they all share one
+# xdist group and run on a single worker.
+_ENGINE_TEST_MODULES = frozenset(
+    {
+        "test_server",
+        "test_snapshot_edge_visibility",
+    }
+)
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        module = item.module.__name__.rsplit(".", 1)[-1] if item.module else ""
+        if module not in _ENGINE_TEST_MODULES:
+            continue
+        if any(mark.name == "xdist_group" for mark in item.iter_markers()):
+            continue
+        item.add_marker(pytest.mark.xdist_group(name="engine"))
+
 
 @pytest.fixture
 def cube_kcl():

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -18,6 +18,7 @@ from kittycad.models.modeling_cmd import (
     OptionViewIsometric,
     OptionZoomToFit,
 )
+from kittycad.models.modeling_session_data import ModelingSessionData
 from kittycad.models.ok_modeling_cmd_response import (
     OkModelingCmdResponse,
 )
@@ -26,8 +27,10 @@ from kittycad.models.ok_modeling_cmd_response import (
 )
 from kittycad.models.ok_web_socket_response_data import (
     ModelingData,
+    ModelingSessionDataData,
     OkWebSocketResponseData,
     OptionModeling,
+    OptionModelingSessionData,
 )
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
 from kittycad.models.uuid import Uuid
@@ -106,6 +109,47 @@ def test_send_modeling_command_skips_another_commands_failure_frame():
             request = websocket.send.call_args.args[0].root
             frames.append(
                 _failure_frame("00000000-0000-0000-0000-000000000000", "stale error")
+            )
+            frames.append(_ok_frame(request.cmd_id, expected_response))
+        return frames.pop(0)
+
+    websocket.recv.side_effect = recv
+
+    result = zoo_tools._send_modeling_command(
+        cast(Any, websocket),
+        ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+        ResponseEntityGetIndex,
+        "entity index",
+    )
+
+    assert result == expected_response
+
+
+def test_send_modeling_command_skips_unsolicited_session_frames():
+    """A live session interleaves informational frames that carry no request_id."""
+    websocket = MagicMock()
+    expected_response = ResponseEntityGetIndex(data=EntityGetIndex(entity_index=9))
+    frames: list[SimpleNamespace] = []
+
+    def recv() -> SimpleNamespace:
+        if not frames:
+            request = websocket.send.call_args.args[0].root
+            frames.append(
+                SimpleNamespace(
+                    root=SuccessWebSocketResponse(
+                        request_id=None,
+                        resp=OkWebSocketResponseData(
+                            OptionModelingSessionData(
+                                data=ModelingSessionDataData(
+                                    session=ModelingSessionData(
+                                        api_call_id="api-call-id"
+                                    )
+                                )
+                            )
+                        ),
+                        success=True,
+                    )
+                )
             )
             frames.append(_ok_frame(request.cmd_id, expected_response))
         return frames.pop(0)

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -1,0 +1,251 @@
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from kittycad.models import (
+    CurveGetEndPoints,
+    CurveGetType,
+    EdgeGetLength,
+    EngineUtilEvaluatePath,
+    EntityGetAllChildUuids,
+    EntityGetIndex,
+    EntityGetParentId,
+    EntityGetSketchPaths,
+    EntityReference,
+    EntityType,
+    HighlightSetEntities,
+    ModelingCmd,
+    Point2d,
+    Point3d,
+    SceneSelectionType,
+    SelectEntity,
+    SelectWithPoint,
+    SetSelectionFilter,
+)
+from kittycad.models.entity_reference import OptionFace
+from kittycad.models.modeling_cmd import (
+    OptionCurveGetEndPoints,
+    OptionCurveGetType,
+    OptionEdgeGetLength,
+    OptionEngineUtilEvaluatePath,
+    OptionEntityGetAllChildUuids,
+    OptionEntityGetIndex,
+    OptionEntityGetParentId,
+    OptionEntityGetSketchPaths,
+    OptionHighlightSetEntities,
+    OptionSelectEntity,
+    OptionSelectWithPoint,
+    OptionSetSelectionFilter,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OkModelingCmdResponse,
+)
+from kittycad.models.ok_modeling_cmd_response import (
+    OptionEntityGetIndex as ResponseEntityGetIndex,
+)
+from kittycad.models.ok_web_socket_response_data import (
+    ModelingData,
+    OkWebSocketResponseData,
+    OptionModeling,
+)
+from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
+from kittycad.models.uuid import Uuid
+
+from zoo_mcp import zoo_tools
+
+
+def test_send_modeling_command_returns_matching_typed_response():
+    websocket = MagicMock()
+    response_data = EntityGetIndex(entity_index=4)
+    expected_response = ResponseEntityGetIndex(data=response_data)
+
+    def recv() -> SimpleNamespace:
+        request = websocket.send.call_args.args[0].root
+        response = SuccessWebSocketResponse(
+            request_id=request.cmd_id,
+            resp=OkWebSocketResponseData(
+                OptionModeling(
+                    data=ModelingData(
+                        modeling_response=OkModelingCmdResponse(expected_response)
+                    )
+                )
+            ),
+            success=True,
+        )
+        return SimpleNamespace(root=response)
+
+    websocket.recv.side_effect = recv
+    result = zoo_tools._send_modeling_command(
+        cast(Any, websocket),
+        ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+        ResponseEntityGetIndex,
+        "entity index",
+    )
+
+    assert result == expected_response
+    request = websocket.send.call_args.args[0].root
+    assert request.cmd.root.model_dump() == {
+        "entity_id": "entity-id",
+        "type": "entity_get_index",
+    }
+
+
+@pytest.mark.parametrize(
+    ("call", "request_type", "request_fields", "response_type", "response_data"),
+    [
+        (
+            lambda: zoo_tools.zoo_select_with_point(
+                "code",
+                None,
+                Point2d(x=10, y=20),
+                SceneSelectionType.ADD,
+            ),
+            OptionSelectWithPoint,
+            {
+                "selected_at_window": {"x": 10.0, "y": 20.0},
+                "selection_type": "add",
+            },
+            zoo_tools.ResponseSelectWithPoint,
+            SelectWithPoint(entity_id="selected-id"),
+        ),
+        (
+            lambda: zoo_tools.zoo_set_selection_filter(
+                "code", None, [EntityType.FACE, EntityType.EDGE]
+            ),
+            OptionSetSelectionFilter,
+            {"filter": ["face", "edge"]},
+            zoo_tools.ResponseSetSelectionFilter,
+            SetSelectionFilter(),
+        ),
+        (
+            lambda: zoo_tools.zoo_select_entity(
+                "code",
+                None,
+                [EntityReference(OptionFace(face_id="face-id"))],
+            ),
+            OptionSelectEntity,
+            {
+                "entities": [
+                    {
+                        "face_id": "face-id",
+                        "topology_fallback": None,
+                        "type": "face",
+                    }
+                ]
+            },
+            zoo_tools.ResponseSelectEntity,
+            SelectEntity(),
+        ),
+        (
+            lambda: zoo_tools.zoo_curve_get_end_points("code", None, Uuid("curve-id")),
+            OptionCurveGetEndPoints,
+            {"curve_id": "curve-id"},
+            zoo_tools.ResponseCurveGetEndPoints,
+            CurveGetEndPoints(
+                start=Point3d(x=0, y=0, z=0),
+                end=Point3d(x=1, y=2, z=3),
+            ),
+        ),
+        (
+            lambda: zoo_tools.zoo_engine_util_evaluate_path(
+                "code", None, '{"type":"line"}', 0.25
+            ),
+            OptionEngineUtilEvaluatePath,
+            {"path_json": '{"type":"line"}', "t": 0.25},
+            zoo_tools.ResponseEngineUtilEvaluatePath,
+            EngineUtilEvaluatePath(pos=Point3d(x=1, y=2, z=3)),
+        ),
+        (
+            lambda: zoo_tools.zoo_curve_get_type("code", None, Uuid("curve-id")),
+            OptionCurveGetType,
+            {"curve_id": "curve-id"},
+            zoo_tools.ResponseCurveGetType,
+            CurveGetType(curve_type="line"),
+        ),
+        (
+            lambda: zoo_tools.zoo_edge_get_length("code", None, Uuid("edge-id")),
+            OptionEdgeGetLength,
+            {"edge_id": "edge-id"},
+            zoo_tools.ResponseEdgeGetLength,
+            EdgeGetLength(length=12.5),
+        ),
+        (
+            lambda: zoo_tools.zoo_entity_get_all_child_uuids(
+                "code", None, Uuid("entity-id")
+            ),
+            OptionEntityGetAllChildUuids,
+            {"entity_id": "entity-id"},
+            zoo_tools.ResponseEntityGetAllChildUuids,
+            EntityGetAllChildUuids(entity_ids=["child-id"]),
+        ),
+        (
+            lambda: zoo_tools.zoo_entity_get_index("code", None, Uuid("entity-id")),
+            OptionEntityGetIndex,
+            {"entity_id": "entity-id"},
+            zoo_tools.ResponseEntityGetIndex,
+            EntityGetIndex(entity_index=3),
+        ),
+        (
+            lambda: zoo_tools.zoo_entity_get_parent_id("code", None, Uuid("entity-id")),
+            OptionEntityGetParentId,
+            {"entity_id": "entity-id"},
+            zoo_tools.ResponseEntityGetParentId,
+            EntityGetParentId(entity_id="parent-id"),
+        ),
+        (
+            lambda: zoo_tools.zoo_entity_get_sketch_paths(
+                "code", None, Uuid("entity-id")
+            ),
+            OptionEntityGetSketchPaths,
+            {"entity_id": "entity-id"},
+            zoo_tools.ResponseEntityGetSketchPaths,
+            EntityGetSketchPaths(entity_ids=["path-id"]),
+        ),
+        (
+            lambda: zoo_tools.zoo_highlight_set_entities(
+                "code", None, ["entity-1", "entity-2"]
+            ),
+            OptionHighlightSetEntities,
+            {"entities": ["entity-1", "entity-2"]},
+            zoo_tools.ResponseHighlightSetEntities,
+            HighlightSetEntities(),
+        ),
+    ],
+)
+def test_modeling_tool_constructs_expected_command(
+    monkeypatch: pytest.MonkeyPatch,
+    call: Callable[[], object],
+    request_type: type,
+    request_fields: dict[str, object],
+    response_type: type,
+    response_data: object,
+):
+    captured: dict[str, object] = {}
+
+    def execute(
+        kcl_code: str | None,
+        kcl_path: object,
+        command: ModelingCmd,
+        expected_response: type,
+        response_description: str,
+    ) -> SimpleNamespace:
+        captured.update(
+            kcl_code=kcl_code,
+            kcl_path=kcl_path,
+            command=command,
+            expected_response=expected_response,
+            response_description=response_description,
+        )
+        return SimpleNamespace(data=response_data)
+
+    monkeypatch.setattr(zoo_tools, "_execute_project_modeling_command", execute)
+
+    assert call() is response_data
+    assert captured["kcl_code"] == "code"
+    assert captured["kcl_path"] is None
+    command = cast(ModelingCmd, captured["command"])
+    assert isinstance(command.root, request_type)
+    assert command.root.model_dump(exclude={"type"}) == request_fields
+    assert captured["expected_response"] is response_type

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -13,6 +14,8 @@ from kittycad.models import (
 from kittycad.models.api_error import ApiError
 from kittycad.models.failure_web_socket_response import FailureWebSocketResponse
 from kittycad.models.modeling_cmd import (
+    OptionDefaultCameraSetOrthographic,
+    OptionEdgeLinesVisible,
     OptionEntityGetIndex,
     OptionTakeSnapshot,
     OptionViewIsometric,
@@ -420,11 +423,16 @@ def test_exec_kcl_project_reads_with_a_timeout(monkeypatch: pytest.MonkeyPatch):
     assert result == {"nodes": {}}
 
 
-def test_snapshot_frames_the_scene_before_capturing(monkeypatch: pytest.MonkeyPatch):
+def _capture_snapshot_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[ModelingCmd]:
+    """Record the command sequence zoo_snapshot sends, stubbing the transport."""
     commands: list[ModelingCmd] = []
     responses = {
+        zoo_tools.ResponseDefaultCameraSetOrthographic: SimpleNamespace(data=None),
         zoo_tools.ResponseViewIsometric: SimpleNamespace(data=None),
         zoo_tools.ResponseZoomToFit: SimpleNamespace(data=None),
+        zoo_tools.ResponseEdgeLinesVisible: SimpleNamespace(data=None),
         zoo_tools.ResponseTakeSnapshot: SimpleNamespace(
             data=TakeSnapshot(contents="anBlZw==")
         ),
@@ -439,14 +447,19 @@ def test_snapshot_frames_the_scene_before_capturing(monkeypatch: pytest.MonkeyPa
         commands.append(command)
         return responses[cast(Any, expected_response)]
 
-    resize = MagicMock(return_value=b"resized-jpeg")
     monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
-    monkeypatch.setattr(zoo_tools, "resize_image", resize)
     monkeypatch.setattr(
         zoo_tools,
         "_modeling_websocket",
-        lambda *args, **kwargs: __import__("contextlib").nullcontext(MagicMock()),
+        lambda *args, **kwargs: nullcontext(MagicMock()),
     )
+    return commands
+
+
+def test_snapshot_frames_the_scene_before_capturing(monkeypatch: pytest.MonkeyPatch):
+    commands = _capture_snapshot_commands(monkeypatch)
+    resize = MagicMock(return_value=b"resized-jpeg")
+    monkeypatch.setattr(zoo_tools, "resize_image", resize)
 
     result = zoo_tools.zoo_snapshot(
         kcl_code=None,
@@ -457,33 +470,75 @@ def test_snapshot_frames_the_scene_before_capturing(monkeypatch: pytest.MonkeyPa
 
     assert result == b"resized-jpeg"
     assert [type(command.root) for command in commands] == [
+        OptionDefaultCameraSetOrthographic,
         OptionViewIsometric,
         OptionZoomToFit,
+        OptionEdgeLinesVisible,
         OptionTakeSnapshot,
     ]
-    assert cast(Any, commands[2].root).format == "jpeg"
+    assert cast(Any, commands[-1].root).format == "jpeg"
     resize.assert_called_once_with(b"jpeg", 256)
 
 
-def test_snapshot_can_preserve_the_current_camera(monkeypatch: pytest.MonkeyPatch):
-    commands: list[ModelingCmd] = []
-
-    def send_command(
-        ws: object,
-        command: ModelingCmd,
-        expected_response: type,
-        description: str,
-    ) -> object:
-        commands.append(command)
-        return SimpleNamespace(data=TakeSnapshot(contents="anBlZw=="))
-
-    monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
+def test_snapshot_hides_edge_lines_by_default(monkeypatch: pytest.MonkeyPatch):
+    """Edge outlines otherwise compete with highlight_set_entities."""
+    commands = _capture_snapshot_commands(monkeypatch)
     monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
-    monkeypatch.setattr(
-        zoo_tools,
-        "_modeling_websocket",
-        lambda *args, **kwargs: __import__("contextlib").nullcontext(MagicMock()),
+
+    zoo_tools.zoo_snapshot(kcl_code=None, kcl_path=None, session_id="session-id")
+
+    edge_commands = [
+        command.root
+        for command in commands
+        if isinstance(command.root, OptionEdgeLinesVisible)
+    ]
+    assert len(edge_commands) == 1
+    assert cast(Any, edge_commands[0]).hidden is True
+
+
+def test_snapshot_can_show_edge_lines(monkeypatch: pytest.MonkeyPatch):
+    commands = _capture_snapshot_commands(monkeypatch)
+    monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
+
+    zoo_tools.zoo_snapshot(
+        kcl_code=None,
+        kcl_path=None,
+        session_id="session-id",
+        highlight_edges=True,
     )
+
+    edge_commands = [
+        command.root
+        for command in commands
+        if isinstance(command.root, OptionEdgeLinesVisible)
+    ]
+    assert len(edge_commands) == 1
+    assert cast(Any, edge_commands[0]).hidden is False
+
+
+def test_snapshot_always_uses_orthographic_projection(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Perspective projection distorts measurements read off the image."""
+    monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
+
+    for zoom in (True, False):
+        commands = _capture_snapshot_commands(monkeypatch)
+        zoo_tools.zoo_snapshot(
+            kcl_code=None,
+            kcl_path=None,
+            session_id="session-id",
+            zoom=zoom,
+        )
+        assert any(
+            isinstance(command.root, OptionDefaultCameraSetOrthographic)
+            for command in commands
+        ), f"zoom={zoom} did not set an orthographic camera"
+
+
+def test_snapshot_can_preserve_the_current_camera(monkeypatch: pytest.MonkeyPatch):
+    commands = _capture_snapshot_commands(monkeypatch)
+    monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
 
     zoo_tools.zoo_snapshot(
         kcl_code=None,
@@ -492,7 +547,11 @@ def test_snapshot_can_preserve_the_current_camera(monkeypatch: pytest.MonkeyPatc
         zoom=False,
     )
 
-    assert [type(command.root) for command in commands] == [OptionTakeSnapshot]
+    # No isometric/zoom-to-fit: the caller's framing is left alone.
+    assert not any(
+        isinstance(command.root, OptionViewIsometric | OptionZoomToFit)
+        for command in commands
+    )
 
 
 def test_face_info_uuid_type_is_accepted():

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -17,12 +17,10 @@ from kittycad.models import (
     EntityType,
     HighlightSetEntities,
     ModelingCmd,
-    Point2d,
     Point3d,
-    SceneSelectionType,
     SelectEntity,
-    SelectWithPoint,
     SetSelectionFilter,
+    TakeSnapshot,
 )
 from kittycad.models.entity_reference import OptionFace
 from kittycad.models.modeling_cmd import (
@@ -36,8 +34,8 @@ from kittycad.models.modeling_cmd import (
     OptionEntityGetSketchPaths,
     OptionHighlightSetEntities,
     OptionSelectEntity,
-    OptionSelectWithPoint,
     OptionSetSelectionFilter,
+    OptionTakeSnapshot,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OkModelingCmdResponse,
@@ -175,21 +173,6 @@ async def test_execute_kcl_executes_in_modeling_session(
 @pytest.mark.parametrize(
     ("call", "request_type", "request_fields", "response_type", "response_data"),
     [
-        (
-            lambda: zoo_tools.zoo_select_with_point(
-                "code",
-                None,
-                Point2d(x=10, y=20),
-                SceneSelectionType.ADD,
-            ),
-            OptionSelectWithPoint,
-            {
-                "selected_at_window": {"x": 10.0, "y": 20.0},
-                "selection_type": "add",
-            },
-            zoo_tools.ResponseSelectWithPoint,
-            SelectWithPoint(entity_id="selected-id"),
-        ),
         (
             lambda: zoo_tools.zoo_set_selection_filter(
                 "code", None, [EntityType.FACE, EntityType.EDGE]
@@ -332,3 +315,26 @@ def test_modeling_tool_constructs_expected_command(
     assert isinstance(command.root, request_type)
     assert command.root.model_dump(exclude={"type"}) == request_fields
     assert captured["expected_response"] is response_type
+
+
+def test_snapshot_constructs_expected_command(monkeypatch: pytest.MonkeyPatch):
+    response_data = TakeSnapshot(contents="anBlZw==")
+    execute = MagicMock(return_value=SimpleNamespace(data=response_data))
+    resize = MagicMock(return_value=b"resized-jpeg")
+    monkeypatch.setattr(zoo_tools, "_execute_project_modeling_command", execute)
+    monkeypatch.setattr(zoo_tools, "resize_image", resize)
+
+    result = zoo_tools.zoo_snapshot(
+        kcl_code=None,
+        kcl_path=None,
+        session_id="session-id",
+        max_image_dimension=256,
+    )
+
+    assert result == b"resized-jpeg"
+    command = cast(ModelingCmd, execute.call_args.args[2])
+    assert isinstance(command.root, OptionTakeSnapshot)
+    assert command.root.format == "jpeg"
+    assert execute.call_args.args[3] is zoo_tools.ResponseTakeSnapshot
+    assert execute.call_args.args[5] == "session-id"
+    resize.assert_called_once_with(b"jpeg", 256)

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -1,41 +1,22 @@
-from collections.abc import Callable
+import threading
+import time
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 from kittycad.models import (
-    CurveGetEndPoints,
-    CurveGetType,
-    EdgeGetLength,
-    EngineUtilEvaluatePath,
-    EntityGetAllChildUuids,
     EntityGetIndex,
-    EntityGetParentId,
-    EntityGetSketchPaths,
-    EntityReference,
-    EntityType,
-    HighlightSetEntities,
     ModelingCmd,
-    Point3d,
-    SelectEntity,
-    SetSelectionFilter,
     TakeSnapshot,
 )
-from kittycad.models.entity_reference import OptionFace
+from kittycad.models.api_error import ApiError
+from kittycad.models.failure_web_socket_response import FailureWebSocketResponse
 from kittycad.models.modeling_cmd import (
-    OptionCurveGetEndPoints,
-    OptionCurveGetType,
-    OptionEdgeGetLength,
-    OptionEngineUtilEvaluatePath,
-    OptionEntityGetAllChildUuids,
     OptionEntityGetIndex,
-    OptionEntityGetParentId,
-    OptionEntityGetSketchPaths,
-    OptionHighlightSetEntities,
-    OptionSelectEntity,
-    OptionSetSelectionFilter,
     OptionTakeSnapshot,
+    OptionViewIsometric,
+    OptionZoomToFit,
 )
 from kittycad.models.ok_modeling_cmd_response import (
     OkModelingCmdResponse,
@@ -50,8 +31,43 @@ from kittycad.models.ok_web_socket_response_data import (
 )
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
 from kittycad.models.uuid import Uuid
+from websockets.exceptions import ConnectionClosedError
 
 from zoo_mcp import ZooMCPException, zoo_tools
+
+
+@pytest.fixture(autouse=True)
+def _clear_modeling_sessions():
+    """Keep module-level session state from leaking between tests."""
+    zoo_tools.zoo_stop_all_modeling_sessions()
+    yield
+    zoo_tools.zoo_stop_all_modeling_sessions()
+
+
+def _ok_frame(request_id: object, response: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        root=SuccessWebSocketResponse(
+            request_id=cast(Any, request_id),
+            resp=OkWebSocketResponseData(
+                OptionModeling(
+                    data=ModelingData(
+                        modeling_response=OkModelingCmdResponse(cast(Any, response))
+                    )
+                )
+            ),
+            success=True,
+        )
+    )
+
+
+def _failure_frame(request_id: object, message: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        root=FailureWebSocketResponse(
+            request_id=cast(Any, request_id),
+            errors=[ApiError(error_code=cast(Any, "bad_request"), message=message)],
+            success=False,
+        )
+    )
 
 
 def test_send_modeling_command_returns_matching_typed_response():
@@ -61,18 +77,7 @@ def test_send_modeling_command_returns_matching_typed_response():
 
     def recv() -> SimpleNamespace:
         request = websocket.send.call_args.args[0].root
-        response = SuccessWebSocketResponse(
-            request_id=request.cmd_id,
-            resp=OkWebSocketResponseData(
-                OptionModeling(
-                    data=ModelingData(
-                        modeling_response=OkModelingCmdResponse(expected_response)
-                    )
-                )
-            ),
-            success=True,
-        )
-        return SimpleNamespace(root=response)
+        return _ok_frame(request.cmd_id, expected_response)
 
     websocket.recv.side_effect = recv
     result = zoo_tools._send_modeling_command(
@@ -90,10 +95,58 @@ def test_send_modeling_command_returns_matching_typed_response():
     }
 
 
+def test_send_modeling_command_skips_another_commands_failure_frame():
+    """A stale failure frame must not be reported as this command's error."""
+    websocket = MagicMock()
+    expected_response = ResponseEntityGetIndex(data=EntityGetIndex(entity_index=7))
+    frames: list[SimpleNamespace] = []
+
+    def recv() -> SimpleNamespace:
+        if not frames:
+            request = websocket.send.call_args.args[0].root
+            frames.append(
+                _failure_frame("00000000-0000-0000-0000-000000000000", "stale error")
+            )
+            frames.append(_ok_frame(request.cmd_id, expected_response))
+        return frames.pop(0)
+
+    websocket.recv.side_effect = recv
+
+    result = zoo_tools._send_modeling_command(
+        cast(Any, websocket),
+        ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+        ResponseEntityGetIndex,
+        "entity index",
+    )
+
+    assert result == expected_response
+
+
+def test_send_modeling_command_raises_readable_message_for_own_failure():
+    websocket = MagicMock()
+
+    def recv() -> SimpleNamespace:
+        request = websocket.send.call_args.args[0].root
+        return _failure_frame(request.cmd_id, "No such entity exists")
+
+    websocket.recv.side_effect = recv
+
+    with pytest.raises(ZooMCPException) as exc_info:
+        zoo_tools._send_modeling_command(
+            cast(Any, websocket),
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+        )
+
+    message = str(exc_info.value)
+    assert "bad_request: No such entity exists" in message
+    assert "errors=" not in message
+
+
 def test_modeling_session_starts_empty_then_executes_and_reuses_websocket(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    zoo_tools.zoo_stop_all_modeling_sessions()
     context = MagicMock()
     websocket = MagicMock()
     context.__enter__.return_value = websocket
@@ -111,14 +164,16 @@ def test_modeling_session_starts_empty_then_executes_and_reuses_websocket(
         kcl_code="code",
         session_id=session_id,
     )
-    result = zoo_tools.zoo_entity_get_index(
-        kcl_code=None,
-        kcl_path=None,
-        entity_id=Uuid("entity-id"),
-        session_id=session_id,
+    result = zoo_tools.zoo_execute_modeling_command(
+        None,
+        None,
+        ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+        ResponseEntityGetIndex,
+        "entity index",
+        session_id,
     )
 
-    assert result == expected_response.data
+    assert result == expected_response
     assert artifact_graph == {}
     execute_project.assert_called_once()
     assert execute_project.call_args.args[0] is websocket
@@ -127,16 +182,17 @@ def test_modeling_session_starts_empty_then_executes_and_reuses_websocket(
     zoo_tools.zoo_stop_modeling_session(session_id)
     context.__exit__.assert_called_once_with(None, None, None)
     with pytest.raises(ZooMCPException, match="Unknown modeling session"):
-        zoo_tools.zoo_entity_get_index(
-            kcl_code=None,
-            kcl_path=None,
-            entity_id=Uuid("entity-id"),
-            session_id=session_id,
+        zoo_tools.zoo_execute_modeling_command(
+            None,
+            None,
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+            session_id,
         )
 
 
 def test_modeling_session_start_does_not_execute_kcl(monkeypatch: pytest.MonkeyPatch):
-    zoo_tools.zoo_stop_all_modeling_sessions()
     context = MagicMock()
     context.__enter__.return_value = MagicMock()
     execute_project = MagicMock()
@@ -150,6 +206,105 @@ def test_modeling_session_start_does_not_execute_kcl(monkeypatch: pytest.MonkeyP
     context.__exit__.assert_called_once_with(None, None, None)
 
 
+def test_session_registry_lock_is_not_held_while_waiting_for_a_busy_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A queued caller must not block unrelated session management."""
+    context = MagicMock()
+    context.__enter__.return_value = MagicMock()
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold() -> None:
+        with zoo_tools._modeling_websocket(None, None, session_id):
+            holding.set()
+            release.wait(timeout=5)
+
+    def queue_behind() -> None:
+        with zoo_tools._modeling_websocket(None, None, session_id):
+            pass
+
+    holder = threading.Thread(target=hold)
+    holder.start()
+    assert holding.wait(timeout=5)
+    queued = threading.Thread(target=queue_behind)
+    queued.start()
+    time.sleep(0.2)
+
+    started = time.monotonic()
+    other_session_id = zoo_tools.zoo_start_modeling_session()
+    elapsed = time.monotonic() - started
+
+    release.set()
+    holder.join(timeout=5)
+    queued.join(timeout=5)
+    zoo_tools.zoo_stop_modeling_session(other_session_id)
+    zoo_tools.zoo_stop_modeling_session(session_id)
+
+    assert elapsed < 0.5, (
+        f"starting an unrelated session blocked for {elapsed:.2f}s behind a busy one"
+    )
+
+
+def test_session_is_evicted_when_its_websocket_dies(monkeypatch: pytest.MonkeyPatch):
+    context = MagicMock()
+    context.__enter__.return_value = MagicMock()
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+
+    with (
+        pytest.raises(ZooMCPException, match="no longer connected"),
+        zoo_tools._modeling_websocket(None, None, session_id),
+    ):
+        raise ConnectionClosedError(None, None)
+
+    assert session_id not in zoo_tools._modeling_sessions
+    with (
+        pytest.raises(ZooMCPException, match="Unknown modeling session"),
+        zoo_tools._modeling_websocket(None, None, session_id),
+    ):
+        pass
+
+
+def test_idle_sessions_are_reaped_on_start(monkeypatch: pytest.MonkeyPatch):
+    context = MagicMock()
+    context.__enter__.return_value = MagicMock()
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+
+    stale_id = zoo_tools.zoo_start_modeling_session()
+    zoo_tools._modeling_sessions[stale_id].last_used -= (
+        zoo_tools._MODELING_SESSION_IDLE_TIMEOUT + 1
+    )
+
+    fresh_id = zoo_tools.zoo_start_modeling_session()
+
+    assert stale_id not in zoo_tools._modeling_sessions
+    assert fresh_id in zoo_tools._modeling_sessions
+    zoo_tools.zoo_stop_modeling_session(fresh_id)
+
+
+def test_session_count_is_capped(monkeypatch: pytest.MonkeyPatch):
+    context = MagicMock()
+    context.__enter__.return_value = MagicMock()
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+    monkeypatch.setattr(zoo_tools, "_MAX_MODELING_SESSIONS", 2)
+
+    first = zoo_tools.zoo_start_modeling_session()
+    second = zoo_tools.zoo_start_modeling_session()
+
+    with pytest.raises(ZooMCPException, match="Too many open modeling sessions"):
+        zoo_tools.zoo_start_modeling_session()
+
+    zoo_tools.zoo_stop_modeling_session(first)
+    third = zoo_tools.zoo_start_modeling_session()
+    zoo_tools.zoo_stop_modeling_session(second)
+    zoo_tools.zoo_stop_modeling_session(third)
+
+
 @pytest.mark.asyncio
 async def test_execute_kcl_executes_in_modeling_session(
     monkeypatch: pytest.MonkeyPatch,
@@ -157,12 +312,12 @@ async def test_execute_kcl_executes_in_modeling_session(
     execute_project = MagicMock(return_value={})
     monkeypatch.setattr(zoo_tools, "zoo_exec_kcl_project", execute_project)
 
-    result = await zoo_tools.zoo_execute_kcl(
+    succeeded, _ = await zoo_tools.zoo_execute_kcl(
         kcl_code="code",
         session_id="session-id",
     )
 
-    assert result == (True, "KCL code executed successfully")
+    assert succeeded is True
     execute_project.assert_called_once_with(
         kcl_code="code",
         kcl_path=None,
@@ -170,159 +325,84 @@ async def test_execute_kcl_executes_in_modeling_session(
     )
 
 
-@pytest.mark.parametrize(
-    ("call", "request_type", "request_fields", "response_type", "response_data"),
-    [
-        (
-            lambda: zoo_tools.zoo_set_selection_filter(
-                "code", None, [EntityType.FACE, EntityType.EDGE]
-            ),
-            OptionSetSelectionFilter,
-            {"filter": ["face", "edge"]},
-            zoo_tools.ResponseSetSelectionFilter,
-            SetSelectionFilter(),
-        ),
-        (
-            lambda: zoo_tools.zoo_select_entity(
-                "code",
-                None,
-                [EntityReference(OptionFace(face_id="face-id"))],
-            ),
-            OptionSelectEntity,
-            {
-                "entities": [
-                    {
-                        "face_id": "face-id",
-                        "topology_fallback": None,
-                        "type": "face",
-                    }
-                ]
-            },
-            zoo_tools.ResponseSelectEntity,
-            SelectEntity(),
-        ),
-        (
-            lambda: zoo_tools.zoo_curve_get_end_points("code", None, Uuid("curve-id")),
-            OptionCurveGetEndPoints,
-            {"curve_id": "curve-id"},
-            zoo_tools.ResponseCurveGetEndPoints,
-            CurveGetEndPoints(
-                start=Point3d(x=0, y=0, z=0),
-                end=Point3d(x=1, y=2, z=3),
-            ),
-        ),
-        (
-            lambda: zoo_tools.zoo_engine_util_evaluate_path(
-                "code", None, '{"type":"line"}', 0.25
-            ),
-            OptionEngineUtilEvaluatePath,
-            {"path_json": '{"type":"line"}', "t": 0.25},
-            zoo_tools.ResponseEngineUtilEvaluatePath,
-            EngineUtilEvaluatePath(pos=Point3d(x=1, y=2, z=3)),
-        ),
-        (
-            lambda: zoo_tools.zoo_curve_get_type("code", None, Uuid("curve-id")),
-            OptionCurveGetType,
-            {"curve_id": "curve-id"},
-            zoo_tools.ResponseCurveGetType,
-            CurveGetType(curve_type="line"),
-        ),
-        (
-            lambda: zoo_tools.zoo_edge_get_length("code", None, Uuid("edge-id")),
-            OptionEdgeGetLength,
-            {"edge_id": "edge-id"},
-            zoo_tools.ResponseEdgeGetLength,
-            EdgeGetLength(length=12.5),
-        ),
-        (
-            lambda: zoo_tools.zoo_entity_get_all_child_uuids(
-                "code", None, Uuid("entity-id")
-            ),
-            OptionEntityGetAllChildUuids,
-            {"entity_id": "entity-id"},
-            zoo_tools.ResponseEntityGetAllChildUuids,
-            EntityGetAllChildUuids(entity_ids=["child-id"]),
-        ),
-        (
-            lambda: zoo_tools.zoo_entity_get_index("code", None, Uuid("entity-id")),
-            OptionEntityGetIndex,
-            {"entity_id": "entity-id"},
-            zoo_tools.ResponseEntityGetIndex,
-            EntityGetIndex(entity_index=3),
-        ),
-        (
-            lambda: zoo_tools.zoo_entity_get_parent_id("code", None, Uuid("entity-id")),
-            OptionEntityGetParentId,
-            {"entity_id": "entity-id"},
-            zoo_tools.ResponseEntityGetParentId,
-            EntityGetParentId(entity_id="parent-id"),
-        ),
-        (
-            lambda: zoo_tools.zoo_entity_get_sketch_paths(
-                "code", None, Uuid("entity-id")
-            ),
-            OptionEntityGetSketchPaths,
-            {"entity_id": "entity-id"},
-            zoo_tools.ResponseEntityGetSketchPaths,
-            EntityGetSketchPaths(entity_ids=["path-id"]),
-        ),
-        (
-            lambda: zoo_tools.zoo_highlight_set_entities(
-                "code", None, ["entity-1", "entity-2"]
-            ),
-            OptionHighlightSetEntities,
-            {"entities": ["entity-1", "entity-2"]},
-            zoo_tools.ResponseHighlightSetEntities,
-            HighlightSetEntities(),
-        ),
-    ],
-)
-def test_modeling_tool_constructs_expected_command(
+@pytest.mark.asyncio
+async def test_execute_kcl_session_message_states_diagnostics_are_unavailable(
     monkeypatch: pytest.MonkeyPatch,
-    call: Callable[[], object],
-    request_type: type,
-    request_fields: dict[str, object],
-    response_type: type,
-    response_data: object,
 ):
-    captured: dict[str, object] = {}
+    """The engine's exec response carries no non_fatal list, so say so."""
+    monkeypatch.setattr(zoo_tools, "zoo_exec_kcl_project", MagicMock(return_value={}))
 
-    def execute(
-        kcl_code: str | None,
-        kcl_path: object,
+    _, message = await zoo_tools.zoo_execute_kcl(
+        kcl_code="code",
+        session_id="session-id",
+    )
+
+    assert "Non-fatal diagnostics" in message
+    assert "not" in message
+
+
+def test_exec_kcl_project_reads_with_a_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Reading the raw socket without a timeout would hang forever."""
+    websocket = MagicMock()
+    websocket._recv_timeout = 12.5
+    sent: dict[str, object] = {}
+
+    def send(payload: str) -> None:
+        import json
+
+        sent.update(json.loads(payload))
+
+    websocket.ws.send.side_effect = send
+
+    def recv(timeout: float | None = None) -> str:
+        import json
+
+        assert timeout == 12.5
+        return json.dumps(
+            {
+                "success": True,
+                "request_id": sent["request_id"],
+                "resp": {
+                    "type": "exec_kcl_project",
+                    "data": {"result": {"Ok": {"artifact_graph": {"nodes": {}}}}},
+                },
+            }
+        )
+
+    websocket.ws.recv.side_effect = recv
+
+    result = zoo_tools._exec_kcl_project(cast(Any, websocket), "main.kcl", [])
+
+    assert result == {"nodes": {}}
+
+
+def test_snapshot_frames_the_scene_before_capturing(monkeypatch: pytest.MonkeyPatch):
+    commands: list[ModelingCmd] = []
+    responses = {
+        zoo_tools.ResponseViewIsometric: SimpleNamespace(data=None),
+        zoo_tools.ResponseZoomToFit: SimpleNamespace(data=None),
+        zoo_tools.ResponseTakeSnapshot: SimpleNamespace(
+            data=TakeSnapshot(contents="anBlZw==")
+        ),
+    }
+
+    def send_command(
+        ws: object,
         command: ModelingCmd,
         expected_response: type,
-        response_description: str,
-        session_id: str | None,
-    ) -> SimpleNamespace:
-        captured.update(
-            kcl_code=kcl_code,
-            kcl_path=kcl_path,
-            command=command,
-            expected_response=expected_response,
-            response_description=response_description,
-            session_id=session_id,
-        )
-        return SimpleNamespace(data=response_data)
+        description: str,
+    ) -> object:
+        commands.append(command)
+        return responses[cast(Any, expected_response)]
 
-    monkeypatch.setattr(zoo_tools, "_execute_project_modeling_command", execute)
-
-    assert call() is response_data
-    assert captured["kcl_code"] == "code"
-    assert captured["kcl_path"] is None
-    assert captured["session_id"] is None
-    command = cast(ModelingCmd, captured["command"])
-    assert isinstance(command.root, request_type)
-    assert command.root.model_dump(exclude={"type"}) == request_fields
-    assert captured["expected_response"] is response_type
-
-
-def test_snapshot_constructs_expected_command(monkeypatch: pytest.MonkeyPatch):
-    response_data = TakeSnapshot(contents="anBlZw==")
-    execute = MagicMock(return_value=SimpleNamespace(data=response_data))
     resize = MagicMock(return_value=b"resized-jpeg")
-    monkeypatch.setattr(zoo_tools, "_execute_project_modeling_command", execute)
+    monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
     monkeypatch.setattr(zoo_tools, "resize_image", resize)
+    monkeypatch.setattr(
+        zoo_tools,
+        "_modeling_websocket",
+        lambda *args, **kwargs: __import__("contextlib").nullcontext(MagicMock()),
+    )
 
     result = zoo_tools.zoo_snapshot(
         kcl_code=None,
@@ -332,9 +412,45 @@ def test_snapshot_constructs_expected_command(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert result == b"resized-jpeg"
-    command = cast(ModelingCmd, execute.call_args.args[2])
-    assert isinstance(command.root, OptionTakeSnapshot)
-    assert command.root.format == "jpeg"
-    assert execute.call_args.args[3] is zoo_tools.ResponseTakeSnapshot
-    assert execute.call_args.args[5] == "session-id"
+    assert [type(command.root) for command in commands] == [
+        OptionViewIsometric,
+        OptionZoomToFit,
+        OptionTakeSnapshot,
+    ]
+    assert cast(Any, commands[2].root).format == "jpeg"
     resize.assert_called_once_with(b"jpeg", 256)
+
+
+def test_snapshot_can_preserve_the_current_camera(monkeypatch: pytest.MonkeyPatch):
+    commands: list[ModelingCmd] = []
+
+    def send_command(
+        ws: object,
+        command: ModelingCmd,
+        expected_response: type,
+        description: str,
+    ) -> object:
+        commands.append(command)
+        return SimpleNamespace(data=TakeSnapshot(contents="anBlZw=="))
+
+    monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
+    monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
+    monkeypatch.setattr(
+        zoo_tools,
+        "_modeling_websocket",
+        lambda *args, **kwargs: __import__("contextlib").nullcontext(MagicMock()),
+    )
+
+    zoo_tools.zoo_snapshot(
+        kcl_code=None,
+        kcl_path=None,
+        session_id="session-id",
+        zoom=False,
+    )
+
+    assert [type(command.root) for command in commands] == [OptionTakeSnapshot]
+
+
+def test_face_info_uuid_type_is_accepted():
+    """Guard the Uuid alias the tools pass through to the engine."""
+    assert str(Uuid("face-id")) == "face-id"

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -53,7 +53,7 @@ from kittycad.models.ok_web_socket_response_data import (
 from kittycad.models.success_web_socket_response import SuccessWebSocketResponse
 from kittycad.models.uuid import Uuid
 
-from zoo_mcp import zoo_tools
+from zoo_mcp import ZooMCPException, zoo_tools
 
 
 def test_send_modeling_command_returns_matching_typed_response():
@@ -90,6 +90,86 @@ def test_send_modeling_command_returns_matching_typed_response():
         "entity_id": "entity-id",
         "type": "entity_get_index",
     }
+
+
+def test_modeling_session_starts_empty_then_executes_and_reuses_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    zoo_tools.zoo_stop_all_modeling_sessions()
+    context = MagicMock()
+    websocket = MagicMock()
+    context.__enter__.return_value = websocket
+    execute_project = MagicMock(return_value={})
+    expected_response = ResponseEntityGetIndex(data=EntityGetIndex(entity_index=4))
+    send_command = MagicMock(return_value=expected_response)
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+    monkeypatch.setattr(zoo_tools, "_exec_kcl_project", execute_project)
+    monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+    execute_project.assert_not_called()
+
+    artifact_graph = zoo_tools.zoo_exec_kcl_project(
+        kcl_code="code",
+        session_id=session_id,
+    )
+    result = zoo_tools.zoo_entity_get_index(
+        kcl_code=None,
+        kcl_path=None,
+        entity_id=Uuid("entity-id"),
+        session_id=session_id,
+    )
+
+    assert result == expected_response.data
+    assert artifact_graph == {}
+    execute_project.assert_called_once()
+    assert execute_project.call_args.args[0] is websocket
+    assert send_command.call_args.args[0] is websocket
+
+    zoo_tools.zoo_stop_modeling_session(session_id)
+    context.__exit__.assert_called_once_with(None, None, None)
+    with pytest.raises(ZooMCPException, match="Unknown modeling session"):
+        zoo_tools.zoo_entity_get_index(
+            kcl_code=None,
+            kcl_path=None,
+            entity_id=Uuid("entity-id"),
+            session_id=session_id,
+        )
+
+
+def test_modeling_session_start_does_not_execute_kcl(monkeypatch: pytest.MonkeyPatch):
+    zoo_tools.zoo_stop_all_modeling_sessions()
+    context = MagicMock()
+    context.__enter__.return_value = MagicMock()
+    execute_project = MagicMock()
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+    monkeypatch.setattr(zoo_tools, "_exec_kcl_project", execute_project)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+
+    execute_project.assert_not_called()
+    zoo_tools.zoo_stop_modeling_session(session_id)
+    context.__exit__.assert_called_once_with(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_execute_kcl_executes_in_modeling_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    execute_project = MagicMock(return_value={})
+    monkeypatch.setattr(zoo_tools, "zoo_exec_kcl_project", execute_project)
+
+    result = await zoo_tools.zoo_execute_kcl(
+        kcl_code="code",
+        session_id="session-id",
+    )
+
+    assert result == (True, "KCL code executed successfully")
+    execute_project.assert_called_once_with(
+        kcl_code="code",
+        kcl_path=None,
+        session_id="session-id",
+    )
 
 
 @pytest.mark.parametrize(
@@ -230,6 +310,7 @@ def test_modeling_tool_constructs_expected_command(
         command: ModelingCmd,
         expected_response: type,
         response_description: str,
+        session_id: str | None,
     ) -> SimpleNamespace:
         captured.update(
             kcl_code=kcl_code,
@@ -237,6 +318,7 @@ def test_modeling_tool_constructs_expected_command(
             command=command,
             expected_response=expected_response,
             response_description=response_description,
+            session_id=session_id,
         )
         return SimpleNamespace(data=response_data)
 
@@ -245,6 +327,7 @@ def test_modeling_tool_constructs_expected_command(
     assert call() is response_data
     assert captured["kcl_code"] == "code"
     assert captured["kcl_path"] is None
+    assert captured["session_id"] is None
     command = cast(ModelingCmd, captured["command"])
     assert isinstance(command.root, request_type)
     assert command.root.model_dump(exclude={"type"}) == request_fields

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,13 @@ import pytest
 import pytest_asyncio
 from kittycad import KittyCAD
 from kittycad.exceptions import KittyCADClientError
-from kittycad.models import OrgDataset
+from kittycad.models import (
+    FaceGetCenter,
+    FaceGetGradient,
+    FaceGetPosition,
+    OrgDataset,
+    Point3d,
+)
 from mcp.types import ImageContent, TextContent
 
 import zoo_mcp
@@ -26,6 +32,14 @@ def _meta_result(response: Sequence[Any] | dict[str, Any]) -> Any:
     meta = response[1]
     assert isinstance(meta, dict)
     return cast(dict[str, Any], meta)["result"]
+
+
+def _structured_result(response: Sequence[Any] | dict[str, Any]) -> dict[str, Any]:
+    """Extract structured content with proper typing for ty."""
+    assert isinstance(response, Sequence)
+    result = response[1]
+    assert isinstance(result, dict)
+    return cast(dict[str, Any], result)
 
 
 def _content_list(response: Sequence[Any] | dict[str, Any]) -> list[Any]:
@@ -493,7 +507,7 @@ async def test_exec_kcl_project_tool(monkeypatch):
         arguments={"kcl_code": "sketch = startSketchOn(XY)", "kcl_path": None},
     )
 
-    assert _meta_result(response) == artifact_graph
+    assert _structured_result(response) == artifact_graph
     mock.assert_called_once_with(
         kcl_code="sketch = startSketchOn(XY)",
         kcl_path=None,
@@ -938,22 +952,14 @@ async def test_get_sketch_constraint_status_error():
 
 @pytest.mark.asyncio
 async def test_get_face_info(monkeypatch):
-    face_info = SimpleNamespace(
-        face_get_position=MagicMock(
-            model_dump=MagicMock(return_value={"pos": {"x": 1.0, "y": 2.0, "z": 3.0}})
+    face_info = zoo_mcp.zoo_tools.FaceInfo(
+        face_get_position=FaceGetPosition(pos=Point3d(x=1.0, y=2.0, z=3.0)),
+        face_get_gradient=FaceGetGradient(
+            df_du=Point3d(x=1.0, y=0.0, z=0.0),
+            df_dv=Point3d(x=0.0, y=1.0, z=0.0),
+            normal=Point3d(x=0.0, y=0.0, z=1.0),
         ),
-        face_get_gradient=MagicMock(
-            model_dump=MagicMock(
-                return_value={
-                    "df_du": {"x": 1.0, "y": 0.0, "z": 0.0},
-                    "df_dv": {"x": 0.0, "y": 1.0, "z": 0.0},
-                    "normal": {"x": 0.0, "y": 0.0, "z": 1.0},
-                }
-            )
-        ),
-        face_get_center=MagicMock(
-            model_dump=MagicMock(return_value={"pos": {"x": 0.5, "y": 0.5, "z": 0.0}})
-        ),
+        face_get_center=FaceGetCenter(pos=Point3d(x=0.5, y=0.5, z=0.0)),
     )
     mock = MagicMock(return_value=face_info)
     monkeypatch.setattr("zoo_mcp.server.zoo_face_info", mock)
@@ -967,7 +973,7 @@ async def test_get_face_info(monkeypatch):
         },
     )
 
-    result = _meta_result(response)
+    result = _structured_result(response)
     assert result == {
         "face_get_position": {"pos": {"x": 1.0, "y": 2.0, "z": 3.0}},
         "face_get_gradient": {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -456,7 +456,7 @@ async def test_execute_kcl_error():
 def test_exec_kcl_project_extracts_artifact_graph():
     raw_socket = MagicMock()
 
-    def recv():
+    def recv(timeout: float | None = None):
         request = json.loads(raw_socket.send.call_args.args[0])
         return json.dumps(
             {
@@ -2034,6 +2034,37 @@ async def test_list_org_datasets_empty_when_404(monkeypatch: pytest.MonkeyPatch)
     response = await mcp.call_tool("list_org_datasets", arguments={})
     result = _meta_result(response)
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_org_datasets_empty_when_fallback_hits_404(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Schema drift plus a 404 must still be empty, not an uncaught client error."""
+    with pytest.raises(ValueError) as exc_info:
+        OrgDataset.model_validate({"status": "paused"})
+
+    monkeypatch.setattr(
+        zoo_mcp.zoo_tools.kittycad_client.orgs,
+        "list_org_datasets",
+        MagicMock(side_effect=exc_info.value),
+    )
+    http_client = MagicMock()
+    http_client.get.return_value = SimpleNamespace(is_success=False)
+    monkeypatch.setattr(
+        zoo_mcp.zoo_tools.kittycad_client,
+        "get_http_client",
+        MagicMock(return_value=http_client),
+    )
+    monkeypatch.setattr(
+        "kittycad.response_helpers.raise_for_status",
+        MagicMock(
+            side_effect=KittyCADClientError(message="No org found", status_code=404)
+        ),
+    )
+
+    response = await mcp.call_tool("list_org_datasets", arguments={})
+    assert _meta_result(response) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_asyncio
 from kittycad import KittyCAD
 from kittycad.exceptions import KittyCADClientError
+from kittycad.models import OrgDataset
 from mcp.types import ImageContent, TextContent
 
 import zoo_mcp
@@ -1963,6 +1964,53 @@ async def test_list_org_datasets_success(monkeypatch: pytest.MonkeyPatch):
     assert result == [
         {"id": "uuid-1", "name": "alpha", "description": "first dataset"},
         {"id": "uuid-2", "name": "beta", "description": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_org_datasets_falls_back_for_unknown_status(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    with pytest.raises(ValueError) as exc_info:
+        OrgDataset.model_validate({"status": "paused"})
+
+    monkeypatch.setattr(
+        zoo_mcp.zoo_tools.kittycad_client.orgs,
+        "list_org_datasets",
+        MagicMock(side_effect=exc_info.value),
+    )
+    raw_response = SimpleNamespace(
+        is_success=True,
+        json=MagicMock(
+            return_value={
+                "items": [
+                    {
+                        "id": "uuid-paused",
+                        "name": "paused dataset",
+                        "description": "temporarily paused",
+                        "status": "paused",
+                    }
+                ],
+                "next_page": None,
+            }
+        ),
+    )
+    http_client = MagicMock()
+    http_client.get.return_value = raw_response
+    monkeypatch.setattr(
+        zoo_mcp.zoo_tools.kittycad_client,
+        "get_http_client",
+        MagicMock(return_value=http_client),
+    )
+
+    response = await mcp.call_tool("list_org_datasets", arguments={})
+
+    assert _meta_result(response) == [
+        {
+            "id": "uuid-paused",
+            "name": "paused dataset",
+            "description": "temporarily paused",
+        }
     ]
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -496,6 +496,7 @@ async def test_exec_kcl_project_tool(monkeypatch):
     mock.assert_called_once_with(
         kcl_code="sketch = startSketchOn(XY)",
         kcl_path=None,
+        session_id=None,
     )
 
 
@@ -979,6 +980,7 @@ async def test_get_face_info(monkeypatch):
         kcl_code="cube = startSketchOn(XY)",
         kcl_path=None,
         face_id="face-id",
+        session_id=None,
     )
 
 

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,15 +15,27 @@ from kittycad.models import (
     EntityGetParentId,
     EntityGetSketchPaths,
     EntityReference,
-    EntityType,
-    GlobalAxis,
     HighlightSetEntities,
+    ModelingCmd,
     Point3d,
     SelectEntity,
     SetSelectionFilter,
 )
 from kittycad.models.entity_reference import OptionFace
-from kittycad.models.uuid import Uuid
+from kittycad.models.modeling_cmd import (
+    OptionCurveGetEndPoints,
+    OptionCurveGetType,
+    OptionEdgeGetLength,
+    OptionEngineUtilEvaluatePath,
+    OptionEntityGetAllChildUuids,
+    OptionEntityGetDistance,
+    OptionEntityGetIndex,
+    OptionEntityGetParentId,
+    OptionEntityGetSketchPaths,
+    OptionHighlightSetEntities,
+    OptionSelectEntity,
+    OptionSetSelectionFilter,
+)
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ImageContent
 
@@ -68,56 +81,65 @@ async def test_modeling_tools_are_registered():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("tool_name", "zoo_tool", "arguments", "expected_kwargs", "response_data"),
+    ("tool_name", "arguments", "request_type", "request_fields", "response_data"),
     [
         (
             "entity_distance",
-            "zoo_entity_distance",
+            {"entity_id1": "entity-1", "entity_id2": "entity-2", "on_axis": "x"},
+            OptionEntityGetDistance,
             {
                 "entity_id1": "entity-1",
                 "entity_id2": "entity-2",
-                "on_axis": "x",
-            },
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_id1": Uuid("entity-1"),
-                "entity_id2": Uuid("entity-2"),
-                "on_axis": GlobalAxis.X,
+                "distance_type": {"axis": "x", "type": "on_axis"},
             },
             EntityGetDistance(min_distance=1, max_distance=2),
         ),
         (
-            "set_selection_filter",
-            "zoo_set_selection_filter",
-            {"entity_types": ["face", "edge"]},
+            # The only command builder with a branch: omitting on_axis must
+            # produce a Euclidean distance_type, not an on-axis one.
+            "entity_distance",
+            {"entity_id1": "entity-1", "entity_id2": "entity-2"},
+            OptionEntityGetDistance,
             {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_types": [EntityType.FACE, EntityType.EDGE],
+                "entity_id1": "entity-1",
+                "entity_id2": "entity-2",
+                "distance_type": {"type": "euclidean"},
             },
+            EntityGetDistance(min_distance=0, max_distance=5),
+        ),
+        (
+            "set_selection_filter",
+            {"entity_types": ["face", "edge"], "session_id": "session-id"},
+            OptionSetSelectionFilter,
+            {"filter": ["face", "edge"]},
             SetSelectionFilter(),
         ),
         (
             "select_entity",
-            "zoo_select_entity",
-            {"entities": [{"type": "face", "face_id": "face-id"}]},
             {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entities": [EntityReference(OptionFace(face_id="face-id"))],
+                "entities": [{"type": "face", "face_id": "face-id"}],
+                "session_id": "session-id",
+            },
+            OptionSelectEntity,
+            {
+                "entities": [
+                    {"face_id": "face-id", "topology_fallback": None, "type": "face"}
+                ]
             },
             SelectEntity(),
         ),
         (
+            "highlight_set_entities",
+            {"entity_ids": ["entity-1", "entity-2"], "session_id": "session-id"},
+            OptionHighlightSetEntities,
+            {"entities": ["entity-1", "entity-2"]},
+            HighlightSetEntities(),
+        ),
+        (
             "curve_get_end_points",
-            "zoo_curve_get_end_points",
             {"curve_id": "curve-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "curve_id": Uuid("curve-id"),
-            },
+            OptionCurveGetEndPoints,
+            {"curve_id": "curve-id"},
             CurveGetEndPoints(
                 start=Point3d(x=0, y=0, z=0),
                 end=Point3d(x=1, y=2, z=3),
@@ -125,117 +147,123 @@ async def test_modeling_tools_are_registered():
         ),
         (
             "engine_util_evaluate_path",
-            "zoo_engine_util_evaluate_path",
-            {"path_json": '{"type":"line"}', "t": 0.5},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "path_json": '{"type":"line"}',
-                "t": 0.5,
-            },
+            {"path_json": '{"type":"line"}', "t": 0.25},
+            OptionEngineUtilEvaluatePath,
+            {"path_json": '{"type":"line"}', "t": 0.25},
             EngineUtilEvaluatePath(pos=Point3d(x=1, y=2, z=3)),
         ),
         (
             "curve_get_type",
-            "zoo_curve_get_type",
             {"curve_id": "curve-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "curve_id": Uuid("curve-id"),
-            },
-            CurveGetType(curve_type="arc"),
+            OptionCurveGetType,
+            {"curve_id": "curve-id"},
+            CurveGetType(curve_type="line"),
         ),
         (
             "edge_get_length",
-            "zoo_edge_get_length",
             {"edge_id": "edge-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "edge_id": Uuid("edge-id"),
-            },
+            OptionEdgeGetLength,
+            {"edge_id": "edge-id"},
             EdgeGetLength(length=12.5),
         ),
         (
             "entity_get_all_child_uuids",
-            "zoo_entity_get_all_child_uuids",
             {"entity_id": "entity-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_id": Uuid("entity-id"),
-            },
+            OptionEntityGetAllChildUuids,
+            {"entity_id": "entity-id"},
             EntityGetAllChildUuids(entity_ids=["child-id"]),
         ),
         (
             "entity_get_index",
-            "zoo_entity_get_index",
             {"entity_id": "entity-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_id": Uuid("entity-id"),
-            },
+            OptionEntityGetIndex,
+            {"entity_id": "entity-id"},
             EntityGetIndex(entity_index=3),
         ),
         (
             "entity_get_parent_id",
-            "zoo_entity_get_parent_id",
             {"entity_id": "entity-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_id": Uuid("entity-id"),
-            },
+            OptionEntityGetParentId,
+            {"entity_id": "entity-id"},
             EntityGetParentId(entity_id="parent-id"),
         ),
         (
             "entity_get_sketch_paths",
-            "zoo_entity_get_sketch_paths",
             {"entity_id": "entity-id"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_id": Uuid("entity-id"),
-            },
+            OptionEntityGetSketchPaths,
+            {"entity_id": "entity-id"},
             EntityGetSketchPaths(entity_ids=["path-id"]),
-        ),
-        (
-            "highlight_set_entities",
-            "zoo_highlight_set_entities",
-            {"entity_ids": ["entity-1", "entity-2"]},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "entity_ids": ["entity-1", "entity-2"],
-            },
-            HighlightSetEntities(),
         ),
     ],
 )
-async def test_modeling_tool_maps_arguments_and_returns_structured_response(
+async def test_modeling_tool_builds_expected_command(
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,
-    zoo_tool: str,
     arguments: dict[str, object],
-    expected_kwargs: dict[str, object],
+    request_type: type,
+    request_fields: dict[str, object],
     response_data: object,
 ):
-    mock = MagicMock(return_value=response_data)
-    monkeypatch.setattr(server, zoo_tool, mock)
+    mock = MagicMock(return_value=SimpleNamespace(data=response_data))
+    monkeypatch.setattr(server, "zoo_execute_modeling_command", mock)
 
     response = await mcp.call_tool(tool_name, arguments=arguments)
 
     assert _structured_result(response) == cast(Any, response_data).model_dump()
-    mock.assert_called_once_with(**expected_kwargs, session_id=None)
+    command = cast(ModelingCmd, mock.call_args.args[2])
+    assert isinstance(command.root, request_type)
+    assert command.root.model_dump(exclude={"type"}) == request_fields
+
+
+@pytest.mark.asyncio
+async def test_selection_tools_require_a_session():
+    """Selection state is discarded without a session, so it must be required."""
+    for tool_name, arguments in (
+        ("set_selection_filter", {"entity_types": ["face"]}),
+        ("select_entity", {"entities": [{"type": "face", "face_id": "face-id"}]}),
+        ("highlight_set_entities", {"entity_ids": ["entity-1"]}),
+    ):
+        with pytest.raises(ToolError):
+            await mcp.call_tool(tool_name, arguments=arguments)
+
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    for tool_name in (
+        "set_selection_filter",
+        "select_entity",
+        "highlight_set_entities",
+    ):
+        schema = tools[tool_name].inputSchema
+        assert "session_id" in schema.get("required", []), tool_name
+        assert "kcl_code" not in schema.get("properties", {}), tool_name
+
+
+@pytest.mark.asyncio
+async def test_query_tool_forwards_kcl_and_session(monkeypatch: pytest.MonkeyPatch):
+    mock = MagicMock(
+        return_value=SimpleNamespace(data=EntityGetIndex(entity_index=3)),
+    )
+    monkeypatch.setattr(server, "zoo_execute_modeling_command", mock)
+
+    await mcp.call_tool(
+        "entity_get_index",
+        arguments={"entity_id": "entity-id", "kcl_code": "code"},
+    )
+    assert mock.call_args.args[0] == "code"
+    assert mock.call_args.args[5] is None
+
+    await mcp.call_tool(
+        "entity_get_index",
+        arguments={"entity_id": "entity-id", "session_id": "session-id"},
+    )
+    assert mock.call_args.args[0] is None
+    assert mock.call_args.args[5] == "session-id"
 
 
 @pytest.mark.asyncio
 async def test_modeling_tool_returns_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         server,
-        "zoo_entity_get_index",
+        "zoo_execute_modeling_command",
         MagicMock(side_effect=RuntimeError("boom")),
     )
 
@@ -255,10 +283,7 @@ async def test_start_and_stop_modeling_session_tools(
     monkeypatch.setattr(server, "zoo_start_modeling_session", start)
     monkeypatch.setattr(server, "zoo_stop_modeling_session", stop)
 
-    start_response = await mcp.call_tool(
-        "start_modeling_session",
-        arguments={},
-    )
+    start_response = await mcp.call_tool("start_modeling_session", arguments={})
     stop_response = await mcp.call_tool(
         "stop_modeling_session",
         arguments={"session_id": "session-id"},
@@ -271,26 +296,9 @@ async def test_start_and_stop_modeling_session_tools(
 
 
 @pytest.mark.asyncio
-async def test_modeling_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch):
-    mock = MagicMock(return_value=EntityGetIndex(entity_index=3))
-    monkeypatch.setattr(server, "zoo_entity_get_index", mock)
-
-    response = await mcp.call_tool(
-        "entity_get_index",
-        arguments={"entity_id": "entity-id", "session_id": "session-id"},
-    )
-
-    assert _structured_result(response) == {"entity_index": 3}
-    mock.assert_called_once_with(
-        kcl_code=None,
-        kcl_path=None,
-        entity_id=Uuid("entity-id"),
-        session_id="session-id",
-    )
-
-
-@pytest.mark.asyncio
-async def test_snapshot_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch):
+async def test_snapshot_tool_forwards_session_and_zoom(
+    monkeypatch: pytest.MonkeyPatch,
+):
     mock = MagicMock(return_value=b"jpeg")
     monkeypatch.setattr(server, "zoo_snapshot", mock)
 
@@ -309,7 +317,14 @@ async def test_snapshot_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch
         kcl_path=None,
         session_id="session-id",
         max_image_dimension=256,
+        zoom=True,
     )
+
+    await mcp.call_tool(
+        "snapshot",
+        arguments={"session_id": "session-id", "zoom": False},
+    )
+    assert mock.call_args.kwargs["zoom"] is False
 
 
 @pytest.mark.asyncio
@@ -342,3 +357,28 @@ async def test_kcl_execution_tools_forward_session_id(
         kcl_path=None,
         session_id="session-id",
     )
+
+
+@pytest.mark.asyncio
+async def test_query_tools_document_their_arguments():
+    """Docstrings are the LLM-facing contract; every parameter needs one."""
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    for tool_name in (
+        "curve_get_type",
+        "edge_get_length",
+        "entity_get_all_child_uuids",
+        "entity_get_index",
+        "entity_get_parent_id",
+        "entity_get_sketch_paths",
+        "curve_get_end_points",
+        "entity_distance",
+    ):
+        description = tools[tool_name].description or ""
+        assert "Args:" in description, tool_name
+        assert "session_id:" in description, tool_name
+
+
+@pytest.mark.asyncio
+async def test_entity_reference_is_still_exported():
+    """select_entity's schema depends on this alias."""
+    assert EntityReference(OptionFace(face_id="face-id")) is not None

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -318,6 +318,7 @@ async def test_snapshot_tool_forwards_session_and_zoom(
         session_id="session-id",
         max_image_dimension=256,
         zoom=True,
+        highlight_edges=False,
     )
 
     await mcp.call_tool(
@@ -325,6 +326,12 @@ async def test_snapshot_tool_forwards_session_and_zoom(
         arguments={"session_id": "session-id", "zoom": False},
     )
     assert mock.call_args.kwargs["zoom"] is False
+
+    await mcp.call_tool(
+        "snapshot",
+        arguments={"session_id": "session-id", "highlight_edges": True},
+    )
+    assert mock.call_args.kwargs["highlight_edges"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -1,0 +1,251 @@
+from collections.abc import Sequence
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from kittycad.models import (
+    CurveGetEndPoints,
+    CurveGetType,
+    EdgeGetLength,
+    EngineUtilEvaluatePath,
+    EntityGetAllChildUuids,
+    EntityGetDistance,
+    EntityGetIndex,
+    EntityGetParentId,
+    EntityGetSketchPaths,
+    EntityReference,
+    EntityType,
+    GlobalAxis,
+    HighlightSetEntities,
+    Point2d,
+    Point3d,
+    SceneSelectionType,
+    SelectEntity,
+    SelectWithPoint,
+    SetSelectionFilter,
+)
+from kittycad.models.entity_reference import OptionFace
+from kittycad.models.uuid import Uuid
+
+from zoo_mcp import server
+from zoo_mcp.server import mcp
+
+
+def _result(response: Sequence[Any] | dict[str, Any]) -> Any:
+    assert isinstance(response, Sequence)
+    meta = response[1]
+    assert isinstance(meta, dict)
+    return cast(dict[str, Any], meta)["result"]
+
+
+@pytest.mark.asyncio
+async def test_modeling_tools_are_registered():
+    names = {tool.name for tool in await mcp.list_tools()}
+    assert {
+        "entity_distance",
+        "select_with_point",
+        "set_selection_filter",
+        "select_entity",
+        "curve_get_end_points",
+        "engine_util_evaluate_path",
+        "curve_get_type",
+        "edge_get_length",
+        "entity_get_all_child_uuids",
+        "entity_get_index",
+        "entity_get_parent_id",
+        "entity_get_sketch_paths",
+        "highlight_set_entities",
+    } <= names
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "zoo_tool", "arguments", "expected_kwargs", "response_data"),
+    [
+        (
+            "entity_distance",
+            "zoo_entity_distance",
+            {
+                "entity_id1": "entity-1",
+                "entity_id2": "entity-2",
+                "on_axis": "x",
+            },
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_id1": Uuid("entity-1"),
+                "entity_id2": Uuid("entity-2"),
+                "on_axis": GlobalAxis.X,
+            },
+            EntityGetDistance(min_distance=1, max_distance=2),
+        ),
+        (
+            "select_with_point",
+            "zoo_select_with_point",
+            {"x": 10, "y": 20, "selection_type": "add"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "selected_at_window": Point2d(x=10, y=20),
+                "selection_type": SceneSelectionType.ADD,
+            },
+            SelectWithPoint(entity_id="selected-id"),
+        ),
+        (
+            "set_selection_filter",
+            "zoo_set_selection_filter",
+            {"entity_types": ["face", "edge"]},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_types": [EntityType.FACE, EntityType.EDGE],
+            },
+            SetSelectionFilter(),
+        ),
+        (
+            "select_entity",
+            "zoo_select_entity",
+            {"entities": [{"type": "face", "face_id": "face-id"}]},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entities": [EntityReference(OptionFace(face_id="face-id"))],
+            },
+            SelectEntity(),
+        ),
+        (
+            "curve_get_end_points",
+            "zoo_curve_get_end_points",
+            {"curve_id": "curve-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "curve_id": Uuid("curve-id"),
+            },
+            CurveGetEndPoints(
+                start=Point3d(x=0, y=0, z=0),
+                end=Point3d(x=1, y=2, z=3),
+            ),
+        ),
+        (
+            "engine_util_evaluate_path",
+            "zoo_engine_util_evaluate_path",
+            {"path_json": '{"type":"line"}', "t": 0.5},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "path_json": '{"type":"line"}',
+                "t": 0.5,
+            },
+            EngineUtilEvaluatePath(pos=Point3d(x=1, y=2, z=3)),
+        ),
+        (
+            "curve_get_type",
+            "zoo_curve_get_type",
+            {"curve_id": "curve-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "curve_id": Uuid("curve-id"),
+            },
+            CurveGetType(curve_type="arc"),
+        ),
+        (
+            "edge_get_length",
+            "zoo_edge_get_length",
+            {"edge_id": "edge-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "edge_id": Uuid("edge-id"),
+            },
+            EdgeGetLength(length=12.5),
+        ),
+        (
+            "entity_get_all_child_uuids",
+            "zoo_entity_get_all_child_uuids",
+            {"entity_id": "entity-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_id": Uuid("entity-id"),
+            },
+            EntityGetAllChildUuids(entity_ids=["child-id"]),
+        ),
+        (
+            "entity_get_index",
+            "zoo_entity_get_index",
+            {"entity_id": "entity-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_id": Uuid("entity-id"),
+            },
+            EntityGetIndex(entity_index=3),
+        ),
+        (
+            "entity_get_parent_id",
+            "zoo_entity_get_parent_id",
+            {"entity_id": "entity-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_id": Uuid("entity-id"),
+            },
+            EntityGetParentId(entity_id="parent-id"),
+        ),
+        (
+            "entity_get_sketch_paths",
+            "zoo_entity_get_sketch_paths",
+            {"entity_id": "entity-id"},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_id": Uuid("entity-id"),
+            },
+            EntityGetSketchPaths(entity_ids=["path-id"]),
+        ),
+        (
+            "highlight_set_entities",
+            "zoo_highlight_set_entities",
+            {"entity_ids": ["entity-1", "entity-2"]},
+            {
+                "kcl_code": None,
+                "kcl_path": None,
+                "entity_ids": ["entity-1", "entity-2"],
+            },
+            HighlightSetEntities(),
+        ),
+    ],
+)
+async def test_modeling_tool_maps_arguments_and_serializes_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    zoo_tool: str,
+    arguments: dict[str, object],
+    expected_kwargs: dict[str, object],
+    response_data: object,
+):
+    mock = MagicMock(return_value=response_data)
+    monkeypatch.setattr(server, zoo_tool, mock)
+
+    response = await mcp.call_tool(tool_name, arguments=arguments)
+
+    assert _result(response) == cast(Any, response_data).model_dump()
+    mock.assert_called_once_with(**expected_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_modeling_tool_returns_error(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        server,
+        "zoo_entity_get_index",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    response = await mcp.call_tool(
+        "entity_get_index",
+        arguments={"entity_id": "entity-id", "kcl_code": "code"},
+    )
+
+    assert _result(response) == "Failed to get entity index: boom"

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -332,6 +333,54 @@ async def test_snapshot_tool_forwards_session_and_zoom(
         arguments={"session_id": "session-id", "highlight_edges": True},
     )
     assert mock.call_args.kwargs["highlight_edges"] is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_tool_writes_to_output_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """output_path returns the saved path instead of an inline image."""
+    monkeypatch.setattr(server, "zoo_snapshot", MagicMock(return_value=b"jpeg-bytes"))
+    output_path = tmp_path / "snap.jpg"
+
+    response = await mcp.call_tool(
+        "snapshot",
+        arguments={"session_id": "session-id", "output_path": str(output_path)},
+    )
+
+    result = _result(response)
+    assert Path(result) == output_path.resolve()
+    assert output_path.read_bytes() == b"jpeg-bytes"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_tool_output_path_accepts_a_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    monkeypatch.setattr(server, "zoo_snapshot", MagicMock(return_value=b"jpeg-bytes"))
+
+    response = await mcp.call_tool(
+        "snapshot",
+        arguments={"session_id": "session-id", "output_path": str(tmp_path)},
+    )
+
+    result = _result(response)
+    assert Path(result) == (tmp_path / "image.jpg").resolve()
+    assert (tmp_path / "image.jpg").read_bytes() == b"jpeg-bytes"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_tool_returns_image_when_output_path_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(server, "zoo_snapshot", MagicMock(return_value=b"jpeg-bytes"))
+
+    response = await mcp.call_tool("snapshot", arguments={"session_id": "session-id"})
+
+    assert isinstance(response, Sequence)
+    content = response[0]
+    assert isinstance(content, list)
+    assert isinstance(content[0], ImageContent)
 
 
 @pytest.mark.asyncio

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -26,6 +26,7 @@ from kittycad.models import (
 )
 from kittycad.models.entity_reference import OptionFace
 from kittycad.models.uuid import Uuid
+from mcp.server.fastmcp.exceptions import ToolError
 
 from zoo_mcp import server
 from zoo_mcp.server import mcp
@@ -36,6 +37,13 @@ def _result(response: Sequence[Any] | dict[str, Any]) -> Any:
     meta = response[1]
     assert isinstance(meta, dict)
     return cast(dict[str, Any], meta)["result"]
+
+
+def _structured_result(response: Sequence[Any] | dict[str, Any]) -> dict[str, Any]:
+    assert isinstance(response, Sequence)
+    result = response[1]
+    assert isinstance(result, dict)
+    return cast(dict[str, Any], result)
 
 
 @pytest.mark.asyncio
@@ -220,7 +228,7 @@ async def test_modeling_tools_are_registered():
         ),
     ],
 )
-async def test_modeling_tool_maps_arguments_and_serializes_response(
+async def test_modeling_tool_maps_arguments_and_returns_structured_response(
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,
     zoo_tool: str,
@@ -233,7 +241,7 @@ async def test_modeling_tool_maps_arguments_and_serializes_response(
 
     response = await mcp.call_tool(tool_name, arguments=arguments)
 
-    assert _result(response) == cast(Any, response_data).model_dump()
+    assert _structured_result(response) == cast(Any, response_data).model_dump()
     mock.assert_called_once_with(**expected_kwargs, session_id=None)
 
 
@@ -245,12 +253,11 @@ async def test_modeling_tool_returns_error(monkeypatch: pytest.MonkeyPatch):
         MagicMock(side_effect=RuntimeError("boom")),
     )
 
-    response = await mcp.call_tool(
-        "entity_get_index",
-        arguments={"entity_id": "entity-id", "kcl_code": "code"},
-    )
-
-    assert _result(response) == "Failed to get entity index: boom"
+    with pytest.raises(ToolError, match="Error executing tool entity_get_index: boom"):
+        await mcp.call_tool(
+            "entity_get_index",
+            arguments={"entity_id": "entity-id", "kcl_code": "code"},
+        )
 
 
 @pytest.mark.asyncio
@@ -271,8 +278,8 @@ async def test_start_and_stop_modeling_session_tools(
         arguments={"session_id": "session-id"},
     )
 
-    assert _result(start_response) == {"session_id": "session-id"}
-    assert _result(stop_response) == {"stopped_session_id": "session-id"}
+    assert _result(start_response) == "session-id"
+    assert _result(stop_response) is None
     start.assert_called_once_with()
     stop.assert_called_once_with("session-id")
 
@@ -287,7 +294,7 @@ async def test_modeling_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch
         arguments={"entity_id": "entity-id", "session_id": "session-id"},
     )
 
-    assert _result(response) == {"entity_index": 3}
+    assert _structured_result(response) == {"entity_index": 3}
     mock.assert_called_once_with(
         kcl_code=None,
         kcl_path=None,
@@ -315,7 +322,7 @@ async def test_kcl_execution_tools_forward_session_id(
     )
 
     assert _result(execute_response) == [True, "KCL code executed successfully"]
-    assert _result(project_response) == {"item_count": 1}
+    assert _structured_result(project_response) == {"item_count": 1}
     execute.assert_awaited_once_with(
         kcl_code="code",
         kcl_path=None,

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -8,6 +8,7 @@ import pytest
 from kittycad.models import (
     CurveGetEndPoints,
     CurveGetType,
+    DefaultCameraCenterToSelection,
     EdgeGetLength,
     EngineUtilEvaluatePath,
     EntityGetAllChildUuids,
@@ -15,17 +16,16 @@ from kittycad.models import (
     EntityGetIndex,
     EntityGetParentId,
     EntityGetSketchPaths,
-    EntityReference,
     HighlightSetEntities,
     ModelingCmd,
     Point3d,
-    SelectEntity,
+    SelectReplace,
     SetSelectionFilter,
 )
-from kittycad.models.entity_reference import OptionFace
 from kittycad.models.modeling_cmd import (
     OptionCurveGetEndPoints,
     OptionCurveGetType,
+    OptionDefaultCameraCenterToSelection,
     OptionEdgeGetLength,
     OptionEngineUtilEvaluatePath,
     OptionEntityGetAllChildUuids,
@@ -34,7 +34,7 @@ from kittycad.models.modeling_cmd import (
     OptionEntityGetParentId,
     OptionEntityGetSketchPaths,
     OptionHighlightSetEntities,
-    OptionSelectEntity,
+    OptionSelectReplace,
     OptionSetSelectionFilter,
 )
 from mcp.server.fastmcp.exceptions import ToolError
@@ -64,7 +64,8 @@ async def test_modeling_tools_are_registered():
     assert {
         "entity_distance",
         "set_selection_filter",
-        "select_entity",
+        "select_entities",
+        "center_camera_on_selection",
         "curve_get_end_points",
         "engine_util_evaluate_path",
         "curve_get_type",
@@ -116,25 +117,32 @@ async def test_modeling_tools_are_registered():
             SetSelectionFilter(),
         ),
         (
-            "select_entity",
-            {
-                "entities": [{"type": "face", "face_id": "face-id"}],
-                "session_id": "session-id",
-            },
-            OptionSelectEntity,
-            {
-                "entities": [
-                    {"face_id": "face-id", "topology_fallback": None, "type": "face"}
-                ]
-            },
-            SelectEntity(),
-        ),
-        (
             "highlight_set_entities",
             {"entity_ids": ["entity-1", "entity-2"], "session_id": "session-id"},
             OptionHighlightSetEntities,
             {"entities": ["entity-1", "entity-2"]},
             HighlightSetEntities(),
+        ),
+        (
+            "select_entities",
+            {"entity_ids": ["entity-1", "entity-2"], "session_id": "session-id"},
+            OptionSelectReplace,
+            {"entities": ["entity-1", "entity-2"]},
+            SelectReplace(),
+        ),
+        (
+            "center_camera_on_selection",
+            {"session_id": "session-id"},
+            OptionDefaultCameraCenterToSelection,
+            {"camera_movement": "vantage"},
+            DefaultCameraCenterToSelection(),
+        ),
+        (
+            "center_camera_on_selection",
+            {"session_id": "session-id", "move_vantage": False},
+            OptionDefaultCameraCenterToSelection,
+            {"camera_movement": "none"},
+            DefaultCameraCenterToSelection(),
         ),
         (
             "curve_get_end_points",
@@ -221,8 +229,9 @@ async def test_selection_tools_require_a_session():
     """Selection state is discarded without a session, so it must be required."""
     for tool_name, arguments in (
         ("set_selection_filter", {"entity_types": ["face"]}),
-        ("select_entity", {"entities": [{"type": "face", "face_id": "face-id"}]}),
+        ("select_entities", {"entity_ids": ["entity-1"]}),
         ("highlight_set_entities", {"entity_ids": ["entity-1"]}),
+        ("center_camera_on_selection", {}),
     ):
         with pytest.raises(ToolError):
             await mcp.call_tool(tool_name, arguments=arguments)
@@ -230,12 +239,33 @@ async def test_selection_tools_require_a_session():
     tools = {tool.name: tool for tool in await mcp.list_tools()}
     for tool_name in (
         "set_selection_filter",
-        "select_entity",
+        "select_entities",
         "highlight_set_entities",
+        "center_camera_on_selection",
     ):
         schema = tools[tool_name].inputSchema
         assert "session_id" in schema.get("required", []), tool_name
         assert "kcl_code" not in schema.get("properties", {}), tool_name
+
+
+@pytest.mark.asyncio
+async def test_emphasis_guidance_is_documented():
+    """The relative strength of highlight vs selection is easy to get wrong."""
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+    highlight = tools["highlight_set_entities"].description or ""
+    assert "select_entities" in highlight
+    assert "center_camera_on_selection" in highlight
+
+    select = tools["select_entities"].description or ""
+    assert "highlight_set_entities" in select
+
+
+@pytest.mark.asyncio
+async def test_only_one_selection_tool_is_exposed():
+    """Two selection tools with different argument shapes invite the wrong pick."""
+    names = {tool.name for tool in await mcp.list_tools()}
+    assert "select_entities" in names
+    assert "select_entity" not in names
 
 
 @pytest.mark.asyncio
@@ -432,9 +462,3 @@ async def test_query_tools_document_their_arguments():
         description = tools[tool_name].description or ""
         assert "Args:" in description, tool_name
         assert "session_id:" in description, tool_name
-
-
-@pytest.mark.asyncio
-async def test_entity_reference_is_still_exported():
-    """select_entity's schema depends on this alias."""
-    assert EntityReference(OptionFace(face_id="face-id")) is not None

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from kittycad.models import (
@@ -55,6 +55,8 @@ async def test_modeling_tools_are_registered():
         "entity_get_parent_id",
         "entity_get_sketch_paths",
         "highlight_set_entities",
+        "start_modeling_session",
+        "stop_modeling_session",
     } <= names
 
 
@@ -232,7 +234,7 @@ async def test_modeling_tool_maps_arguments_and_serializes_response(
     response = await mcp.call_tool(tool_name, arguments=arguments)
 
     assert _result(response) == cast(Any, response_data).model_dump()
-    mock.assert_called_once_with(**expected_kwargs)
+    mock.assert_called_once_with(**expected_kwargs, session_id=None)
 
 
 @pytest.mark.asyncio
@@ -249,3 +251,78 @@ async def test_modeling_tool_returns_error(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert _result(response) == "Failed to get entity index: boom"
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_modeling_session_tools(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    start = MagicMock(return_value="session-id")
+    stop = MagicMock()
+    monkeypatch.setattr(server, "zoo_start_modeling_session", start)
+    monkeypatch.setattr(server, "zoo_stop_modeling_session", stop)
+
+    start_response = await mcp.call_tool(
+        "start_modeling_session",
+        arguments={},
+    )
+    stop_response = await mcp.call_tool(
+        "stop_modeling_session",
+        arguments={"session_id": "session-id"},
+    )
+
+    assert _result(start_response) == {"session_id": "session-id"}
+    assert _result(stop_response) == {"stopped_session_id": "session-id"}
+    start.assert_called_once_with()
+    stop.assert_called_once_with("session-id")
+
+
+@pytest.mark.asyncio
+async def test_modeling_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch):
+    mock = MagicMock(return_value=EntityGetIndex(entity_index=3))
+    monkeypatch.setattr(server, "zoo_entity_get_index", mock)
+
+    response = await mcp.call_tool(
+        "entity_get_index",
+        arguments={"entity_id": "entity-id", "session_id": "session-id"},
+    )
+
+    assert _result(response) == {"entity_index": 3}
+    mock.assert_called_once_with(
+        kcl_code=None,
+        kcl_path=None,
+        entity_id=Uuid("entity-id"),
+        session_id="session-id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_kcl_execution_tools_forward_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    execute = AsyncMock(return_value=(True, "KCL code executed successfully"))
+    exec_project = MagicMock(return_value={"item_count": 1})
+    monkeypatch.setattr(server, "zoo_execute_kcl", execute)
+    monkeypatch.setattr(server, "zoo_exec_kcl_project", exec_project)
+
+    execute_response = await mcp.call_tool(
+        "execute_kcl",
+        arguments={"kcl_code": "code", "session_id": "session-id"},
+    )
+    project_response = await mcp.call_tool(
+        "exec_kcl_project",
+        arguments={"kcl_code": "code", "session_id": "session-id"},
+    )
+
+    assert _result(execute_response) == [True, "KCL code executed successfully"]
+    assert _result(project_response) == {"item_count": 1}
+    execute.assert_awaited_once_with(
+        kcl_code="code",
+        kcl_path=None,
+        session_id="session-id",
+    )
+    exec_project.assert_called_once_with(
+        kcl_code="code",
+        kcl_path=None,
+        session_id="session-id",
+    )

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -17,16 +17,14 @@ from kittycad.models import (
     EntityType,
     GlobalAxis,
     HighlightSetEntities,
-    Point2d,
     Point3d,
-    SceneSelectionType,
     SelectEntity,
-    SelectWithPoint,
     SetSelectionFilter,
 )
 from kittycad.models.entity_reference import OptionFace
 from kittycad.models.uuid import Uuid
 from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ImageContent
 
 from zoo_mcp import server
 from zoo_mcp.server import mcp
@@ -51,7 +49,6 @@ async def test_modeling_tools_are_registered():
     names = {tool.name for tool in await mcp.list_tools()}
     assert {
         "entity_distance",
-        "select_with_point",
         "set_selection_filter",
         "select_entity",
         "curve_get_end_points",
@@ -63,6 +60,7 @@ async def test_modeling_tools_are_registered():
         "entity_get_parent_id",
         "entity_get_sketch_paths",
         "highlight_set_entities",
+        "snapshot",
         "start_modeling_session",
         "stop_modeling_session",
     } <= names
@@ -88,18 +86,6 @@ async def test_modeling_tools_are_registered():
                 "on_axis": GlobalAxis.X,
             },
             EntityGetDistance(min_distance=1, max_distance=2),
-        ),
-        (
-            "select_with_point",
-            "zoo_select_with_point",
-            {"x": 10, "y": 20, "selection_type": "add"},
-            {
-                "kcl_code": None,
-                "kcl_path": None,
-                "selected_at_window": Point2d(x=10, y=20),
-                "selection_type": SceneSelectionType.ADD,
-            },
-            SelectWithPoint(entity_id="selected-id"),
         ),
         (
             "set_selection_filter",
@@ -300,6 +286,29 @@ async def test_modeling_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch
         kcl_path=None,
         entity_id=Uuid("entity-id"),
         session_id="session-id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_tool_forwards_session_id(monkeypatch: pytest.MonkeyPatch):
+    mock = MagicMock(return_value=b"jpeg")
+    monkeypatch.setattr(server, "zoo_snapshot", mock)
+
+    response = await mcp.call_tool(
+        "snapshot",
+        arguments={"session_id": "session-id", "max_image_dimension": 256},
+    )
+
+    assert isinstance(response, Sequence)
+    content = response[0]
+    assert isinstance(content, list)
+    assert len(content) == 1
+    assert isinstance(content[0], ImageContent)
+    mock.assert_called_once_with(
+        kcl_code=None,
+        kcl_path=None,
+        session_id="session-id",
+        max_image_dimension=256,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR introduces the "most minimal set" of modeling commands that allow us to further query the topology and spatial information of a model.

Because each tool call would be a new connection to a new engine with another execution, this necessitates better engine connection management. The PR also introduces a `start_modeling_session` (and stop) that LLMs can use at their discretion, instead of being hardcoded-managed by the MCP.

The majority of the PR is pulling through tools from `zoo_tools.py` to `server.py` and a bunch of test code.