### PR TITLE
Forward sketch constraint execution warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,6 @@ dev = [
     "ty",
     "uv-build",
 ]
+
+[tool.uv.sources]
+zoo-kcl = { git = "https://github.com/KittyCAD/modeling-app.git", rev = "6d4b258a2455cebca69b0991c76e6660696836fc", subdirectory = "rust/kcl-python-bindings" }

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -1346,6 +1346,9 @@ def _format_constraint_report(report: kcl.SketchConstraintReport) -> dict:
             _format_constraint_status(s) for s in report.over_constrained
         ],
         "errors": [_format_constraint_status(s) for s in report.errors],
+        "warnings": [
+            {"phase": "execution", "text": warning} for warning in report.warnings
+        ],
         "total_sketches": (
             len(report.fully_constrained)
             + len(report.under_constrained)
@@ -1374,7 +1377,7 @@ async def zoo_get_sketch_constraint_status(
         kcl_path (Path | str | None): KCL path, the path should point to a .kcl file or a directory containing a main.kcl file.
 
     Returns:
-        dict: A report grouping sketches by constraint status (fully_constrained, under_constrained, over_constrained, errors). Also includes kcl_executes_successfully and kcl_error; when KCL parse/execution fails, kcl_executes_successfully is False and kcl_error contains phase and text describing the failure.
+        dict: A report grouping sketches by constraint status (fully_constrained, under_constrained, over_constrained, errors), plus execution warnings. Also includes kcl_executes_successfully and kcl_error; when KCL parse/execution fails, kcl_executes_successfully is False and kcl_error contains phase and text describing the failure.
     """
 
     logger.info("Getting sketch constraint status")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -881,6 +881,33 @@ sketch(on = YZ) {
 
 
 @pytest.mark.asyncio
+async def test_get_sketch_constraint_status_includes_execution_warnings():
+    kcl_code = """
+@settings(defaultLengthUnit = mm)
+
+warningSketch = sketch(on = XY) {
+  horizontalLine = line(start = [var 0mm, var 0mm], end = [var 10mm, var 0mm])
+  verticalLine = line(start = [var 10mm, var 0mm], end = [var 10mm, var 10mm])
+  coincident([horizontalLine.end, verticalLine.start])
+  horizontal(horizontalLine)
+  vertical(verticalLine)
+  angle([horizontalLine, verticalLine]) == 90deg
+}
+"""
+    response = await mcp.call_tool(
+        "get_sketch_constraint_status",
+        arguments={"kcl_code": kcl_code, "kcl_path": None},
+    )
+
+    result = _meta_result(response)
+    assert isinstance(result, dict)
+    assert len(result["warnings"]) == 1
+    assert result["warnings"][0]["phase"] == "execution"
+    assert "Instead of constraining to 90deg" in result["warnings"][0]["text"]
+    assert "constraint to Perpendicular" in result["warnings"][0]["text"]
+
+
+@pytest.mark.asyncio
 async def test_get_sketch_constraint_status_under_constrained_code():
     kcl_code = """
 sketch(on = YZ) {

--- a/uv.lock
+++ b/uv.lock
@@ -1124,20 +1124,7 @@ wheels = [
 [[package]]
 name = "zoo-kcl"
 version = "0.3.176"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/55/cf5c0b686985f69e1ea21b9de16557eddb491eb5fe62306fc9c426fd9753/zoo_kcl-0.3.176.tar.gz", hash = "sha256:bd895e587812a52d6e27dfa7f548573b798590f45cbf364c0df7f889c0a8316f", size = 1182180, upload-time = "2026-08-11T19:55:41.756Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/4c/78eb05789c2f7640dc9f6b7556a6ab981775c817833c4b44d70be73ce651/zoo_kcl-0.3.176-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d85495919f1a338574b58a97472e999f36ac1ab7006d770c473a384b13932de", size = 7598141, upload-time = "2026-08-11T19:55:35.556Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9e/4f734b1190dc1fbe9edd89e0f7f0161c807fa23b884cf81844a76bcd28c8/zoo_kcl-0.3.176-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6881af513e92f7ae545f668e581cca43408f0edb6c939faa0ed96f6a72cb255c", size = 8871637, upload-time = "2026-08-11T19:55:21.66Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/20/9c5f55d506d711e41d6bd30a1c8755fe124ed9481131bbe28ba2b16c21fc/zoo_kcl-0.3.176-cp311-cp311-win_amd64.whl", hash = "sha256:65fe88e189c161c1f026779cb0980d8ae9dd5c6c0f75526c71d07a312bb73b95", size = 8712330, upload-time = "2026-08-11T19:55:43.101Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/b7/a0494cf19e7cd9d02ab57b310bde5440990062acfed19629382963265202/zoo_kcl-0.3.176-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e6f981c6b094eaa40c00030277b44ae341077c3b1795d23d080c25e6e9e778b9", size = 7585659, upload-time = "2026-08-11T19:55:36.892Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9d/a131b82ae34f9443357f8af34e0f9819c4d9117dc12445d5e68bb8635e17/zoo_kcl-0.3.176-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62c3e7ce7ed32e51f6a5c8f57426c1ba29a904059d47dbb1343e0050c95a4376", size = 8859667, upload-time = "2026-08-11T19:55:23.46Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/38/83937df5d5db9120815e940634c2a966de07f959bde879e577a81aa21ce5/zoo_kcl-0.3.176-cp312-cp312-win_amd64.whl", hash = "sha256:bad8da533a21d6df1c848a498bf98bd938ee890eda46b2f45f13503ce1a6ceeb", size = 8713114, upload-time = "2026-08-11T19:55:44.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/92/c273ee208ea8deb30bd191904def918ad97573e82f76af352dfb06f8d22e/zoo_kcl-0.3.176-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a4bcb621ab53aeced8d0d0bf48351a08daf74bbaf70593ba6e87344ffdc3fa4b", size = 7585725, upload-time = "2026-08-11T19:55:38.656Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ebb2633ae5e129f91ecdf96b274f8705589933b132948f4672af3a31ade/zoo_kcl-0.3.176-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4cbeb9560f818b7ffa929ff6c947f77cf009050ca3788b2155b0fccb0a7b479", size = 8858541, upload-time = "2026-08-11T19:55:25.164Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/9e/d2bf74059ac93b30247e3b9ab3cfc3955ef71c87efe1c6f999b226f2c4ff/zoo_kcl-0.3.176-cp313-cp313-win_amd64.whl", hash = "sha256:44515aea137a4ea10f09081bc8b53956984026e1477a82064b165a6a36ab5045", size = 8711458, upload-time = "2026-08-11T19:55:46.361Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/3f/3a5247d9a724f3d8c219dd9db21a89d1e62f1bacd1f57816564abc8c3156/zoo_kcl-0.3.176-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a71bbfb81a11f7412794395b5bf930fbf5054a9e7f77e1c725f42b73daa0de9", size = 8869147, upload-time = "2026-08-11T19:55:33.727Z" },
-]
+source = { git = "https://github.com/KittyCAD/modeling-app.git?subdirectory=rust%2Fkcl-python-bindings&rev=6d4b258a2455cebca69b0991c76e6660696836fc#6d4b258a2455cebca69b0991c76e6660696836fc" }
 
 [[package]]
 name = "zoo-mcp"
@@ -1174,7 +1161,7 @@ requires-dist = [
     { name = "trimesh", specifier = "<6.0" },
     { name = "truststore", specifier = "<1.0" },
     { name = "typing-extensions", specifier = ">=4.12" },
-    { name = "zoo-kcl", specifier = ">=0.3.176" },
+    { name = "zoo-kcl", git = "https://github.com/KittyCAD/modeling-app.git?subdirectory=rust%2Fkcl-python-bindings&rev=6d4b258a2455cebca69b0991c76e6660696836fc" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- forward execution warnings returned by `SketchConstraintReport` through `get_sketch_constraint_status`
- preserve the existing TTC-compatible warning shape with `phase: execution` and rendered diagnostic text
- pin zoo-kcl to KittyCAD/modeling-app#12986 while the binding change is under review

## Why

This exposes warnings from the constraint-status execution to consumers of the current MCP API. TTC #4043 does **not** depend on this PR: TTC currently uses MCP 0.19, while this PR targets MCP 0.21, whose snapshot API is not yet compatible with TTC. TTC therefore reads the combined KCL report directly for now.

## Known blockers before merge

- KittyCAD/modeling-app#12986 currently carries warning-level diagnostics only. Its report contract must also preserve completed-run error/fatal diagnostics before downstream callers can use it as a full replacement for separate execution validation.
- After the modeling-app change merges, a new zoo-kcl package must be published. Replace the temporary Git source pin and raise the declared minimum zoo-kcl version to that release; `tool.uv.sources` does not update wheel dependency metadata.

Depends on KittyCAD/modeling-app#12986.

## Validation

- `uv run pytest tests/test_server.py -k get_sketch_constraint_status_includes_execution_warnings -q`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run ty check`