### PR TITLE
Skip org datasets excluded from lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ This is a Model Context Protocol (MCP) server that exposes Zoo CAD and KCL utili
 The server connects to Zoo's KCL execution APIs using the KittyCAD client, and to `zoo.dev` markdown pages via `httpx` for the docs/samples indexes. All KittyCAD requests require a valid `ZOO_API_TOKEN` environment variable. Notable flows:
 - KCL execution / export tools (in `zoo_tools.py`) use the `kcl` bindings and the KittyCAD client's modeling/execution endpoints.
 - Modeling tools operate on persistent sessions, with at most one session open per server process. Callers use `get_modeling_sessions` to recover the active ID after reconnecting or `start_modeling_session` when none exists, then populate the session through `execute_kcl`, `exec_kcl_project`, or `import_cad_file`. They pass its `session_id` to `snapshot` and query tools and call `stop_modeling_session` when finished. `zoo_snapshot` then loops camera → zoom-to-fit → take-snapshot on that session and tiles the results.
-- Org datasets (`list_org_datasets`, `search_org_dataset_semantic`) call KittyCAD's org-datasets endpoints, with a raw-HTTP fallback when the SDK's pydantic models reject newly-added backend fields.
+- Org datasets (`list_org_datasets`, `search_org_dataset_semantic`) call KittyCAD's org-datasets endpoints, with a raw-HTTP fallback when the SDK's pydantic models reject newly-added backend fields. Listing passes `lookup_enabled=true`, so datasets an org has excluded from lookup are never surfaced or searched.
 - KCL docs/samples (`list_kcl_docs`, `search_kcl_docs`, `get_kcl_doc`, `list_kcl_samples`, `search_kcl_samples`, `get_kcl_sample`) read from the in-memory indexes populated lazily from `zoo.dev` (sitemap-driven for docs, `/aquarium` index for samples).
 
 ### Testing Strategy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.22.0"
+version = "0.22.1"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",
-    "kittycad>=1.4.0,<2.0",
+    "kittycad>=1.5.0,<2.0",
     "mcp[cli]>=1.27.1,<2.0",
     "pillow<13.0",
     "trimesh<6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.22.1"
+version = "0.23.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.22.1",
+  "version": "0.23.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.22.0",
+  "version": "0.22.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -1377,6 +1377,10 @@ async def save_image(
 async def list_org_datasets() -> list[dict] | str:
     """List the datasets available to the user's organization.
 
+    Only datasets the organization has enabled for lookup are listed; datasets
+    excluded from lookup (for example while their conversions are still being
+    worked on) are omitted and should not be searched.
+
     Each dataset has a UUID `id`, a human-readable `name`, and an optional
     `description`. Use the `id` as the `dataset_id` argument to
     `search_org_dataset_semantic`.

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -2066,7 +2066,7 @@ def zoo_snapshot(
     )
 
 
-def _list_org_datasets_raw() -> list[dict[str, str | None]]:
+def _list_org_datasets_raw(lookup_enabled: bool | None) -> list[dict[str, str | None]]:
     """List datasets without validating fields unrelated to this tool's output."""
     client = kittycad_client.get_http_client()
     url = f"{kittycad_client.base_url}/org/datasets"
@@ -2075,7 +2075,13 @@ def _list_org_datasets_raw() -> list[dict[str, str | None]]:
     datasets: list[dict[str, str | None]] = []
 
     while True:
-        params = {"page_token": page_token} if page_token is not None else None
+        # A page token carries the filter forward, so only the first request has
+        # to spell it out; sending both is harmless.
+        params: dict[str, str] = {}
+        if lookup_enabled is not None:
+            params["lookup_enabled"] = "true" if lookup_enabled else "false"
+        if page_token is not None:
+            params["page_token"] = page_token
         response = client.get(
             url=url,
             headers=kittycad_client.get_headers(),
@@ -2128,19 +2134,28 @@ def _org_datasets_empty_or_raise(
     raise ZooMCPException(f"Failed to list org datasets: {exc}") from exc
 
 
-def zoo_list_org_datasets() -> list[dict[str, str | None]]:
+def zoo_list_org_datasets(
+    lookup_enabled: bool | None = True,
+) -> list[dict[str, str | None]]:
     """List all datasets visible to the org tied to the current ZOO_API_TOKEN.
+
+    Args:
+        lookup_enabled: When True (the default), only datasets an org has left
+            enabled for lookup are returned. Pass None to list every dataset
+            regardless of its lookup setting, or False for only the excluded ones.
 
     Returns:
         A list of {"id": <uuid str>, "name": <str>, "description": <str | None>}
         entries, possibly empty.
     """
-    logger.info("Listing org datasets")
+    logger.info("Listing org datasets (lookup_enabled=%s)", lookup_enabled)
     use_raw_fallback = False
     datasets = []
     try:
         datasets = list(
-            kittycad_client.orgs.list_org_datasets(limit=None, page_token=None)
+            kittycad_client.orgs.list_org_datasets(
+                limit=None, page_token=None, lookup_enabled=lookup_enabled
+            )
         )
     except ValueError as exc:
         logger.warning(
@@ -2155,7 +2170,7 @@ def zoo_list_org_datasets() -> list[dict[str, str | None]]:
     # get the 404-means-empty treatment instead of escaping uncaught.
     if use_raw_fallback:
         try:
-            return _list_org_datasets_raw()
+            return _list_org_datasets_raw(lookup_enabled)
         except KittyCADClientError as exc:
             return _org_datasets_empty_or_raise(exc)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1722,10 +1722,11 @@ async def test_list_org_datasets_success(monkeypatch: pytest.MonkeyPatch):
         SimpleNamespace(id="uuid-1", name="alpha", description="first dataset"),
         SimpleNamespace(id="uuid-2", name="beta", description=None),
     ]
+    mock = MagicMock(return_value=iter(fake_datasets))
     monkeypatch.setattr(
         zoo_mcp.kittycad_client.orgs,
         "list_org_datasets",
-        MagicMock(return_value=iter(fake_datasets)),
+        mock,
     )
 
     response = await mcp.call_tool("list_org_datasets", arguments={})
@@ -1734,6 +1735,8 @@ async def test_list_org_datasets_success(monkeypatch: pytest.MonkeyPatch):
         {"id": "uuid-1", "name": "alpha", "description": "first dataset"},
         {"id": "uuid-2", "name": "beta", "description": None},
     ]
+    # Datasets an org excluded from lookup must be filtered out server-side.
+    mock.assert_called_once_with(limit=None, page_token=None, lookup_enabled=True)
 
 
 @pytest.mark.asyncio
@@ -1781,6 +1784,8 @@ async def test_list_org_datasets_falls_back_for_unknown_status(
             "description": "temporarily paused",
         }
     ]
+    # The raw fallback has to filter on lookup too, not just the SDK path.
+    assert http_client.get.call_args.kwargs["params"] == {"lookup_enabled": "true"}
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "kittycad"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -298,9 +298,9 @@ dependencies = [
     { name = "truststore" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/d9/2c4701024d4cdfcaffaf7c2eb4792d9d9cc5d852c405fc72bf2948cb20e7/kittycad-1.4.0.tar.gz", hash = "sha256:2e2b1691d2520843974593dad6cfda67642c7c19142b53e8df87a42b951f2eba", size = 219690, upload-time = "2026-06-25T13:35:18.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/e7/f13acbf2a87781093ab919d725e86402272bdee1de7e80e97aca9592899a/kittycad-1.5.0.tar.gz", hash = "sha256:e186d55e50bb22e4554ef42ee71defda3b47dbb4da4412d9b45e5661337396cb", size = 220636, upload-time = "2026-08-18T20:13:48.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b6/126719b32e015b1cca6991281ad4c3a02e417a68e622401206633cd012ff/kittycad-1.4.0-py3-none-any.whl", hash = "sha256:11ed5ef5187438a570f14d138bf32f67174a0366b3083e91f2f09ad116623a82", size = 386744, upload-time = "2026-06-25T13:35:16.992Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/3807226c6dd2ef2424873fa2885f7b4f1cd9279f43bd5c3d6f90cf984206/kittycad-1.5.0-py3-none-any.whl", hash = "sha256:b051d09cba476ca6c331abcc3fb53c39dbffb4428e497063ad7fd44fbb1846eb", size = 388252, upload-time = "2026-08-18T20:13:47.163Z" },
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1168,7 +1168,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = "<26.0" },
-    { name = "kittycad", specifier = ">=1.4.0,<2.0" },
+    { name = "kittycad", specifier = ">=1.5.0,<2.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.1,<2.0" },
     { name = "pillow", specifier = "<13.0" },
     { name = "trimesh", specifier = "<6.0" },


### PR DESCRIPTION
## Changes

- Bump `kittycad` to `>=1.5.0`, which is where the `lookup_enabled` query parameter and model field arrive.
- `zoo_list_org_datasets` passes `lookup_enabled=True`, so datasets an org excluded from lookup are neither listed to the model nor reachable via `search_org_dataset_semantic` (the ids never surface). The argument defaults to `True` and accepts `None` to list everything.
- The raw-HTTP fallback sends the filter too. It only runs when the SDK's models reject a response, and without it that path would quietly reintroduce the excluded datasets. Later pages keep keying off `page_token` alone, since dropshot embeds the scan params in the token.
- `list_org_datasets`' tool docstring says excluded datasets are omitted and should not be searched.