### PR TITLE
Bound modeling command latency with a wall-clock deadline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This is a Model Context Protocol (MCP) server that exposes Zoo CAD and KCL utili
 - `src/zoo_mcp/kcl_samples.py` - Fetches and indexes KCL samples from `zoo.dev/aquarium` and exposes list/search/get helpers; per-sample file contents are parsed from the per-sample markdown pages on demand.
 - `src/zoo_mcp/utils/data_retrieval_utils.py` - Shared helpers for fetching `zoo.dev` pages safely (path validation, redirect-blocking fetches, markdown excerpting) used by `kcl_docs.py` and `kcl_samples.py`.
 - `src/zoo_mcp/utils/image_utils.py` - Image utilities used by the `snapshot` tool (encoding to MCP `ImageContent`, saving to disk, tiling up to four views into a collage, resizing).
-- `src/zoo_mcp/__init__.py` - Package initialization: configures logging, builds the shared `kittycad_client` (with TLS / websocket settings) used across the modules, defines `ZooMCPException`.
+- `src/zoo_mcp/__init__.py` - Package initialization: configures logging, builds the shared `kittycad_client` (with TLS / websocket settings) used across the modules, defines `ZooMCPException` and `ZooMCPTimeoutError`.
 - `src/zoo_mcp/__main__.py` - `python -m zoo_mcp` entry point; delegates to `server.main`.
 
 ### Key Dependencies
@@ -47,6 +47,7 @@ This is a Model Context Protocol (MCP) server that exposes Zoo CAD and KCL utili
 The server connects to Zoo's KCL execution APIs using the KittyCAD client, and to `zoo.dev` markdown pages via `httpx` for the docs/samples indexes. All KittyCAD requests require a valid `ZOO_API_TOKEN` environment variable. Notable flows:
 - KCL execution / export tools (in `zoo_tools.py`) use the `kcl` bindings and the KittyCAD client's modeling/execution endpoints.
 - Modeling tools operate on persistent sessions, with at most one session open per server process. Callers use `get_modeling_sessions` to recover the active ID after reconnecting or `start_modeling_session` when none exists, then populate the session through `execute_kcl`, `exec_kcl_project`, or `import_cad_file`. They pass its `session_id` to `snapshot` and query tools and call `stop_modeling_session` when finished. `zoo_snapshot` then loops camera → zoom-to-fit → take-snapshot on that session and tiles the results.
+- Every modeling tool call is bounded by `zoo_tools.MODELING_COMMAND_TIMEOUT`, a monotonic wall-clock budget shared by every websocket read the call makes. It cannot be a per-read timeout: a live session interleaves unsolicited frames every ~10s, and each one would restart a per-read timeout, so a stalled import blocked its caller for as long as the connection lived. Expiry raises `ZooMCPTimeoutError` (a `ZooMCPException` subclass, so it is retryable but distinguishable from an engine rejection) and closes and evicts the session. The MCP tools hand these synchronous reads to `asyncio.to_thread`, because MCP dispatches every handler onto one event loop and a blocked read would otherwise stall the whole server rather than just its own call.
 - Org datasets (`list_org_datasets`, `search_org_dataset_semantic`) call KittyCAD's org-datasets endpoints, with a raw-HTTP fallback when the SDK's pydantic models reject newly-added backend fields. Listing passes `lookup_enabled=true`, so datasets an org has excluded from lookup are never surfaced or searched.
 - KCL docs/samples (`list_kcl_docs`, `search_kcl_docs`, `get_kcl_doc`, `list_kcl_samples`, `search_kcl_samples`, `get_kcl_sample`) read from the in-memory indexes populated lazily from `zoo.dev` (sitemap-driven for docs, `/aquarium` index for samples).
 
@@ -55,9 +56,26 @@ Tests live in `tests/` and are split across:
 - `tests/test_server.py` - Exercises every MCP tool end-to-end through `mcp.call_tool`, mixing real KCL/CAD calls with mocked KittyCAD responses for org-dataset tools, and synthetic in-memory indexes for KCL docs/samples tools.
 - `tests/test_docs.py`, `tests/test_samples.py` - Unit tests for the docs categorization / title extraction and the samples markdown index/page parsers.
 - `tests/test_data_retrieval_utils.py` - Unit tests for the shared `zoo.dev` fetch helpers (path safety, excerpt extraction, redirect-blocking fetch, markdown `Accept` header).
-- `tests/test_modeling_commands.py`, `tests/test_server_modeling_commands.py` - Mocked-transport tests for the modeling websocket layer, including the exact command sequence `zoo_snapshot` sends and how the `snapshot` tool resolves its `camera_view` argument.
+- `tests/test_modeling_commands.py`, `tests/test_server_modeling_commands.py` - Mocked-transport tests for the modeling websocket layer, including the exact command sequence `zoo_snapshot` sends, how the `snapshot` tool resolves its `camera_view` argument, and the command deadline (success, engine failure, connection close, a stream of unmatched frames, and no-response timeout). The deadline tests drive a fake monotonic clock so a 300s budget is exercised without a 300s test.
 - `tests/test_live_zoo_dev.py` - Marked `live`; hits `zoo.dev` end-to-end for the docs and samples tools so breakages in the upstream markdown shape are caught. Deselect with `-m "not live"` when offline.
 - All async tests use `pytest-asyncio`.
 
 ## Package Structure
 Built as a standard Python package using setuptools with source code in `src/zoo_mcp/`. The package can be installed via pip/uv or used directly as a module.
+
+### Releasing and versioning
+`server.json` is the manifest `mcp-publisher` publishes to the MCP registry at
+https://registry.modelcontextprotocol.io. It is checked in and read from the repo at release time, so
+its contents — name, description, repository, and the `packages[0]` entry describing the PyPI package,
+its transport, and its environment variables — are what the registry serves to anyone installing this
+server. Treat it as a release artifact, not as documentation.
+
+`release.yml` runs on a pushed tag: build wheels and binaries, publish to PyPI, then publish
+`server.json` to the registry. Bump the version in the same commit in all of:
+- `pyproject.toml` - `version`. `release.yml` builds the wheel straight from it, so this is what lands on PyPI.
+- `server.json` - `packages[0].version`. Nothing in CI rewrites this one, and the registry resolves the PyPI package at exactly this version, which is why the workflow sleeps 60s waiting for the PyPI publish to land first. Leave it stale and the registry entry points at the previous release.
+- `server.json` - the top-level `version`. The workflow overwrites this from the tag (`jq '.version = $v'`) just before publishing, so a stale value will not reach the registry, but keep it in step so the checked-in manifest is not self-contradicting.
+- `uv.lock` - pins this package's own version. Run `uv lock` last and commit the result rather than hand-editing it.
+
+Nothing validates the tag against `pyproject.toml`. Tag `vX.Y.Z` must match the version bumped here, or
+PyPI gets one version while the registry advertises another.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "zoo_mcp"
-version = "0.23.0"
+version = "0.23.1"
 requires-python = ">=3.11, <3.14"
 dependencies = [
     "aiofiles<26.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/KittyCAD/mcp",
     "source": "github"
   },
-  "version": "0.23.0",
+  "version": "0.23.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zoo_mcp",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/zoo_mcp/__init__.py
+++ b/src/zoo_mcp/__init__.py
@@ -30,6 +30,15 @@ class ZooMCPException(Exception):
     """Custom exception for Zoo MCP Server."""
 
 
+class ZooMCPTimeoutError(ZooMCPException):
+    """A modeling command exceeded its wall-clock budget.
+
+    Separate from ZooMCPException so callers can tell "the engine never
+    answered in time", which is worth retrying, apart from "the engine
+    rejected this command", which is not.
+    """
+
+
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 kittycad_client = KittyCAD(verify_ssl=ctx)
 # set the websocket receive timeout to 5 minutes

--- a/src/zoo_mcp/server.py
+++ b/src/zoo_mcp/server.py
@@ -4,6 +4,7 @@ import signal
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import FrameType
+from typing import TypeVar
 
 from kittycad.models import (
     CameraMovement,
@@ -199,6 +200,36 @@ mcp = FastMCP(
     log_level="INFO",
     lifespan=_lifespan,
 )
+
+
+_ModelingResponseT = TypeVar("_ModelingResponseT")
+
+
+async def _modeling_command(
+    command: ModelingCmd,
+    expected_response: type[_ModelingResponseT],
+    response_description: str,
+    session_id: str,
+) -> _ModelingResponseT:
+    """Run a modeling command without holding the event loop.
+
+    The modeling helpers read their websocket synchronously. Called inline from
+    an async tool they stall the whole server rather than just their own call:
+    MCP dispatches every tool handler onto one event loop, so a blocked read
+    starves the other in-flight tools, the stdin reader, and any cancellation
+    the client sends. Handing the read to a worker thread keeps this call
+    awaitable, so it is the tool's deadline that ends a stalled command.
+    """
+    # Called through a closure so the command's response type is resolved here
+    # rather than lost passing a generic function to to_thread.
+    return await asyncio.to_thread(
+        lambda: zoo_execute_modeling_command(
+            command,
+            expected_response,
+            response_description,
+            session_id,
+        )
+    )
 
 
 @mcp.tool()
@@ -528,7 +559,8 @@ async def exec_kcl_project(
     logger.info("exec_kcl_project tool called")
 
     return str(
-        zoo_exec_kcl_project(
+        await asyncio.to_thread(
+            zoo_exec_kcl_project,
             kcl_code=kcl_code,
             kcl_path=kcl_path,
             session_id=session_id,
@@ -555,7 +587,7 @@ async def start_modeling_session() -> str:
         str: The session ID to pass to session-aware modeling tools.
     """
     logger.info("start_modeling_session tool called")
-    return zoo_start_modeling_session()
+    return await asyncio.to_thread(zoo_start_modeling_session)
 
 
 @mcp.tool()
@@ -587,7 +619,9 @@ async def import_cad_file(session_id: str, input_file: str) -> str:
         str: The modeling engine ID of the imported object.
     """
     logger.info("import_cad_file tool called for file: %s", input_file)
-    return zoo_import_cad_file(session_id=session_id, input_file=input_file)
+    return await asyncio.to_thread(
+        zoo_import_cad_file, session_id=session_id, input_file=input_file
+    )
 
 
 @mcp.tool()
@@ -605,7 +639,7 @@ async def stop_modeling_session(session_id: str) -> None:
         None
     """
     logger.info("stop_modeling_session tool called")
-    zoo_stop_modeling_session(session_id)
+    await asyncio.to_thread(zoo_stop_modeling_session, session_id)
 
 
 @mcp.tool()
@@ -717,7 +751,8 @@ async def get_face_info(
     """
     logger.info("get_face_info tool called for face_id=%s", face_id)
 
-    return zoo_face_info(
+    return await asyncio.to_thread(
+        zoo_face_info,
         face_id=Uuid(face_id),
         session_id=session_id,
     )
@@ -742,21 +777,23 @@ async def entity_distance(
         EntityGetDistance: The minimum and maximum distance between the entities.
     """
     logger.info("entity_distance tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(
-            OptionEntityGetDistance(
-                entity_id1=Uuid(entity_id1),
-                entity_id2=Uuid(entity_id2),
-                distance_type=DistanceType(
-                    OptionOnAxis(axis=on_axis)
-                    if on_axis is not None
-                    else OptionEuclidean()
-                ),
-            )
-        ),
-        ResponseEntityGetDistance,
-        "entity distance",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(
+                OptionEntityGetDistance(
+                    entity_id1=Uuid(entity_id1),
+                    entity_id2=Uuid(entity_id2),
+                    distance_type=DistanceType(
+                        OptionOnAxis(axis=on_axis)
+                        if on_axis is not None
+                        else OptionEuclidean()
+                    ),
+                )
+            ),
+            ResponseEntityGetDistance,
+            "entity distance",
+            session_id,
+        )
     ).data
 
 
@@ -776,11 +813,13 @@ async def set_selection_filter(
         SetSelectionFilter: Confirmation that the filter was set.
     """
     logger.info("set_selection_filter tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
-        ResponseSetSelectionFilter,
-        "selection filter",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionSetSelectionFilter(filter=entity_types)),
+            ResponseSetSelectionFilter,
+            "selection filter",
+            session_id,
+        )
     ).data
 
 
@@ -817,11 +856,13 @@ async def select_entities(
         SelectReplace: Confirmation that the selection was replaced.
     """
     logger.info("select_entities tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionSelectReplace(entities=entity_ids)),
-        ResponseSelectReplace,
-        "select entities",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionSelectReplace(entities=entity_ids)),
+            ResponseSelectReplace,
+            "select entities",
+            session_id,
+        )
     ).data
 
 
@@ -851,17 +892,19 @@ async def center_camera_on_selection(
         DefaultCameraCenterToSelection: Confirmation that the camera was centred.
     """
     logger.info("center_camera_on_selection tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(
-            OptionDefaultCameraCenterToSelection(
-                camera_movement=CameraMovement.VANTAGE
-                if move_vantage
-                else CameraMovement.NONE
-            )
-        ),
-        ResponseDefaultCameraCenterToSelection,
-        "camera centering",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(
+                OptionDefaultCameraCenterToSelection(
+                    camera_movement=CameraMovement.VANTAGE
+                    if move_vantage
+                    else CameraMovement.NONE
+                )
+            ),
+            ResponseDefaultCameraCenterToSelection,
+            "camera centering",
+            session_id,
+        )
     ).data
 
 
@@ -897,11 +940,13 @@ async def highlight_set_entities(
         HighlightSetEntities: Confirmation that the highlights were replaced.
     """
     logger.info("highlight_set_entities tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
-        ResponseHighlightSetEntities,
-        "highlight entities",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionHighlightSetEntities(entities=entity_ids)),
+            ResponseHighlightSetEntities,
+            "highlight entities",
+            session_id,
+        )
     ).data
 
 
@@ -920,11 +965,13 @@ async def curve_get_end_points(
         CurveGetEndPoints: The curve's start and end points.
     """
     logger.info("curve_get_end_points tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionCurveGetEndPoints(curve_id=Uuid(curve_id))),
-        ResponseCurveGetEndPoints,
-        "curve endpoints",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionCurveGetEndPoints(curve_id=Uuid(curve_id))),
+            ResponseCurveGetEndPoints,
+            "curve endpoints",
+            session_id,
+        )
     ).data
 
 
@@ -981,11 +1028,13 @@ async def engine_util_evaluate_path(
         EngineUtilEvaluatePath: The position on the path at parameter t.
     """
     logger.info("engine_util_evaluate_path tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
-        ResponseEngineUtilEvaluatePath,
-        "path evaluation",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEngineUtilEvaluatePath(path_json=path_json, t=t)),
+            ResponseEngineUtilEvaluatePath,
+            "path evaluation",
+            session_id,
+        )
     ).data
 
 
@@ -1004,11 +1053,13 @@ async def curve_get_type(
         CurveGetType: The curve's geometric type.
     """
     logger.info("curve_get_type tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionCurveGetType(curve_id=Uuid(curve_id))),
-        ResponseCurveGetType,
-        "curve type",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionCurveGetType(curve_id=Uuid(curve_id))),
+            ResponseCurveGetType,
+            "curve type",
+            session_id,
+        )
     ).data
 
 
@@ -1027,11 +1078,13 @@ async def edge_get_length(
         EdgeGetLength: The edge length in the current scene units.
     """
     logger.info("edge_get_length tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEdgeGetLength(edge_id=Uuid(edge_id))),
-        ResponseEdgeGetLength,
-        "edge length",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEdgeGetLength(edge_id=Uuid(edge_id))),
+            ResponseEdgeGetLength,
+            "edge length",
+            session_id,
+        )
     ).data
 
 
@@ -1050,11 +1103,13 @@ async def entity_get_all_child_uuids(
         EntityGetAllChildUuids: All child entity UUIDs.
     """
     logger.info("entity_get_all_child_uuids tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEntityGetAllChildUuids(entity_id=Uuid(entity_id))),
-        ResponseEntityGetAllChildUuids,
-        "entity child IDs",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEntityGetAllChildUuids(entity_id=Uuid(entity_id))),
+            ResponseEntityGetAllChildUuids,
+            "entity child IDs",
+            session_id,
+        )
     ).data
 
 
@@ -1073,11 +1128,13 @@ async def entity_get_index(
         EntityGetIndex: The entity's index within its parent.
     """
     logger.info("entity_get_index tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEntityGetIndex(entity_id=Uuid(entity_id))),
-        ResponseEntityGetIndex,
-        "entity index",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEntityGetIndex(entity_id=Uuid(entity_id))),
+            ResponseEntityGetIndex,
+            "entity index",
+            session_id,
+        )
     ).data
 
 
@@ -1096,11 +1153,13 @@ async def entity_get_parent_id(
         EntityGetParentId: The parent entity's UUID.
     """
     logger.info("entity_get_parent_id tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEntityGetParentId(entity_id=Uuid(entity_id))),
-        ResponseEntityGetParentId,
-        "entity parent ID",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEntityGetParentId(entity_id=Uuid(entity_id))),
+            ResponseEntityGetParentId,
+            "entity parent ID",
+            session_id,
+        )
     ).data
 
 
@@ -1119,11 +1178,13 @@ async def entity_get_sketch_paths(
         EntityGetSketchPaths: The sketch path UUIDs belonging to the entity.
     """
     logger.info("entity_get_sketch_paths tool called")
-    return zoo_execute_modeling_command(
-        ModelingCmd(OptionEntityGetSketchPaths(entity_id=Uuid(entity_id))),
-        ResponseEntityGetSketchPaths,
-        "entity sketch paths",
-        session_id,
+    return (
+        await _modeling_command(
+            ModelingCmd(OptionEntityGetSketchPaths(entity_id=Uuid(entity_id))),
+            ResponseEntityGetSketchPaths,
+            "entity sketch paths",
+            session_id,
+        )
     ).data
 
 
@@ -1285,7 +1346,8 @@ async def snapshot(
     """
     logger.info("snapshot tool called")
 
-    image = zoo_snapshot(
+    image = await asyncio.to_thread(
+        zoo_snapshot,
         session_id=session_id,
         views=_resolve_camera_views(camera_view),
         max_image_dimension=max_image_dimension,

--- a/src/zoo_mcp/zoo_tools.py
+++ b/src/zoo_mcp/zoo_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 from collections.abc import Awaitable, Callable, Iterator
@@ -7,6 +8,7 @@ from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from threading import Lock
+from time import monotonic
 from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypeVar, cast
 from uuid import uuid4
 
@@ -56,6 +58,7 @@ from kittycad.models import (
     UnitMass,
     UnitVolume,
     WebSocketRequest,
+    WebSocketResponse,
 )
 from kittycad.models.input_format3d import (
     OptionFbx,
@@ -114,10 +117,21 @@ from kittycad.models.uuid import Uuid
 from kittycad.models.web_socket_request import OptionModelingCmdReq
 from websockets.exceptions import WebSocketException
 
-from zoo_mcp import ZooMCPException, kittycad_client, logger
+from zoo_mcp import (
+    ZooMCPException,
+    ZooMCPTimeoutError,
+    kittycad_client,
+    logger,
+)
 from zoo_mcp.utils.image_utils import create_image_collage, resize_image
 
 SUPPORTED_EXTS = {x.value.lower() for x in FileImportFormat} | {"stp"}
+
+# The wall-clock budget for one modeling tool call, measured across every read
+# it makes rather than per read. It has to stay under the reconnect budget of
+# the conversations driving these tools, so a stalled engine surfaces as a
+# retryable error instead of an abandoned request.
+MODELING_COMMAND_TIMEOUT = 300.0
 
 # Map alternative extensions to their canonical FileImportFormat values
 _EXT_ALIASES = {
@@ -692,6 +706,23 @@ def zoo_import_cad_file(session_id: str, input_file: Path | str) -> str:
         raise ZooMCPException(f"'{input_ext}' files cannot be imported")
 
     command_id = ModelingCmdId(uuid4())
+    # Extension and byte size only; the file contents are customer data.
+    file_size = input_file.stat().st_size
+    deadline = _Deadline()
+
+    def log_stage(stage: str, outcome: str) -> None:
+        logger.info(
+            "CAD import %s: session=%s request_id=%s ext=%s bytes=%d "
+            "elapsed=%.3fs outcome=%s",
+            stage,
+            session_id,
+            command_id,
+            input_ext,
+            file_size,
+            deadline.elapsed,
+            outcome,
+        )
+
     with open(input_file, "rb") as data, _modeling_websocket(session_id) as ws:
         ws.send_binary(
             WebSocketRequest(
@@ -706,13 +737,24 @@ def zoo_import_cad_file(session_id: str, input_file: Path | str) -> str:
                 )
             )
         )
+        log_stage("sent", "awaiting-engine-response")
 
-        response = _await_modeling_response(
-            ws,
-            command_id,
-            ResponseImportFiles,
-            "CAD file import",
-        )
+        try:
+            response = _await_modeling_response(
+                ws,
+                command_id,
+                ResponseImportFiles,
+                "CAD file import",
+                deadline,
+            )
+        except ZooMCPTimeoutError:
+            log_stage("finished", "timeout")
+            raise
+        except ZooMCPException as error:
+            log_stage("finished", f"failed ({error})")
+            raise
+
+        log_stage("finished", "imported")
         return response.data.object_id
 
 
@@ -1153,7 +1195,10 @@ async def zoo_execute_kcl(
 
     try:
         if session_id is not None:
-            path_artifact_graph = zoo_exec_kcl_project(
+            # Reads the modeling websocket synchronously; see server._modeling_command
+            # for why that cannot happen on the event loop.
+            path_artifact_graph = await asyncio.to_thread(
+                zoo_exec_kcl_project,
                 kcl_code=kcl_code,
                 kcl_path=kcl_path,
                 session_id=session_id,
@@ -1540,13 +1585,19 @@ def _exec_kcl_project(
     }
     ws.ws.send(json.dumps(request))
 
-    # Mirrors the timeout the SDK's own typed recv() applies; reading the raw
-    # socket without one hangs the caller forever if the engine drops the reply.
-    recv_timeout = getattr(ws, "_recv_timeout", 60.0)
+    # Bounded by what is left of the whole call rather than per read, so the
+    # frames skipped below cannot keep the loop alive indefinitely.
+    deadline = _Deadline()
 
     # This response is not represented in the generated SDK yet.
     while True:
-        raw_response = ws.ws.recv(timeout=recv_timeout)
+        remaining = deadline.remaining
+        if remaining <= 0:
+            raise _modeling_timeout(deadline, "KCL project execution")
+        try:
+            raw_response = ws.ws.recv(timeout=remaining)
+        except TimeoutError as error:
+            raise _modeling_timeout(deadline, "KCL project execution") from error
         try:
             response = json.loads(raw_response)
         except (TypeError, json.JSONDecodeError):
@@ -1627,6 +1678,24 @@ def _close_modeling_session(session: _ModelingSession) -> None:
             session.context.__exit__(None, None, None)
     finally:
         _unlink_modeling_session_artifact_graphs(session)
+
+
+def _discard_modeling_websocket(session: _ModelingSession) -> None:
+    """Close a session's websocket from inside its own command.
+
+    Deliberately not _close_modeling_session: that waits on ``session.lock``,
+    which the command calling this still holds, so it would deadlock.
+    """
+    try:
+        session.context.__exit__(None, None, None)
+    except Exception as error:
+        # The socket is being abandoned anyway; a failure closing it must not
+        # replace the timeout the caller is about to see.
+        logger.warning(
+            "Failed to close timed-out modeling session %s: %s",
+            session.session_id,
+            error,
+        )
 
 
 def _unlink_modeling_session_artifact_graphs(session: _ModelingSession) -> None:
@@ -1757,6 +1826,15 @@ def _modeling_websocket(session_id: str) -> Iterator[WebSocketModelingCommandsWs
     session.lock.acquire()
     try:
         yield session.websocket
+    except ZooMCPTimeoutError:
+        # The engine still owes a response to the command that gave up. Its
+        # request_id no longer matches anything a later command waits for, so
+        # the backlog would silently eat the next command's budget, and the
+        # engine keeps working on the abandoned command either way. Drop the
+        # session rather than hand it back.
+        _evict_modeling_session(session_id)
+        _discard_modeling_websocket(session)
+        raise
     except (WebSocketException, OSError) as error:
         _evict_modeling_session(session_id)
         raise ZooMCPException(
@@ -1836,12 +1914,15 @@ def zoo_face_info(
         face_get_gradient: FaceGetGradient | Literal[False] = False
         face_get_center: FaceGetCenter | Literal[False] = False
 
+        # Shared across all three replies, as for any other single tool call.
+        deadline = _Deadline()
+
         while (
             face_get_position is False
             or face_get_gradient is False
             or face_get_center is False
         ):
-            message = ws.recv().root
+            message = _recv_modeling_frame(ws, deadline, "face info").root
 
             # Match on request_id first; see _send_modeling_command.
             request_id = getattr(message, "request_id", None)
@@ -1891,6 +1972,65 @@ def zoo_face_info(
 _ModelingResponseT = TypeVar("_ModelingResponseT")
 
 
+class _Deadline:
+    """A monotonic wall-clock budget shared by every read in one tool call.
+
+    Monotonic so a clock adjustment mid-import cannot extend or collapse the
+    budget, and shared so that a multi-command call like a multiview snapshot
+    is bounded as a whole rather than per command.
+    """
+
+    __slots__ = ("_started", "timeout")
+
+    def __init__(self, timeout: float | None = None) -> None:
+        # Read at call time, not bound as a default, so a deployment can lower
+        # the budget under its own reconnect window.
+        self.timeout = MODELING_COMMAND_TIMEOUT if timeout is None else timeout
+        self._started = monotonic()
+
+    @property
+    def elapsed(self) -> float:
+        return monotonic() - self._started
+
+    @property
+    def remaining(self) -> float:
+        return self.timeout - self.elapsed
+
+
+def _modeling_timeout(deadline: _Deadline, description: str) -> ZooMCPTimeoutError:
+    return ZooMCPTimeoutError(
+        f"The modeling engine did not return a {description} response within "
+        f"{deadline.timeout:g}s (waited {deadline.elapsed:.1f}s). The modeling "
+        "session was closed; start a new one and retry, and simplify or shrink "
+        "the input if it fails again."
+    )
+
+
+def _recv_modeling_frame(
+    ws: WebSocketModelingCommandsWs,
+    deadline: _Deadline,
+    description: str,
+) -> WebSocketResponse:
+    """Read one frame, bounded by what is left of the whole call's budget.
+
+    The SDK applies its own recv timeout per call, which cannot bound a loop
+    that reads until its command's frame arrives: a live session interleaves
+    unsolicited frames every few seconds, and each one starts a fresh timeout.
+    Passing the remaining budget makes those frames consume it instead.
+    """
+    remaining = deadline.remaining
+    if remaining <= 0:
+        raise _modeling_timeout(deadline, description)
+
+    # Reaching into the SDK's per-read timeout is how the budget gets applied;
+    # recv() takes no timeout argument of its own.
+    ws._recv_timeout = remaining
+    try:
+        return ws.recv()
+    except TimeoutError as error:
+        raise _modeling_timeout(deadline, description) from error
+
+
 def _format_websocket_failure(message: object) -> str:
     """Render an engine failure frame as a readable message, not a model repr."""
     errors = getattr(message, "errors", None)
@@ -1909,10 +2049,11 @@ def _await_modeling_response(
     command_id: ModelingCmdId,
     expected_response: type[_ModelingResponseT],
     response_description: str,
+    deadline: _Deadline,
 ) -> _ModelingResponseT:
-    """Read until the typed response for ``command_id`` arrives."""
+    """Read until the typed response for ``command_id`` arrives or time runs out."""
     while True:
-        message = ws.recv().root
+        message = _recv_modeling_frame(ws, deadline, response_description).root
 
         request_id = getattr(message, "request_id", None)
 
@@ -1947,8 +2088,15 @@ def _send_modeling_command(
     command: ModelingCmd,
     expected_response: type[_ModelingResponseT],
     response_description: str,
+    deadline: _Deadline | None = None,
 ) -> _ModelingResponseT:
-    """Send one modeling command and return its matching typed response."""
+    """Send one modeling command and return its matching typed response.
+
+    Without a ``deadline`` the command gets a budget of its own; callers that
+    send several commands pass one in so the whole sequence is bounded.
+    """
+    if deadline is None:
+        deadline = _Deadline()
     command_id = ModelingCmdId(uuid4())
     ws.send(
         WebSocketRequest(
@@ -1964,6 +2112,7 @@ def _send_modeling_command(
         command_id,
         expected_response,
         response_description,
+        deadline,
     )
 
 
@@ -1980,6 +2129,7 @@ def zoo_execute_modeling_command(
             command,
             expected_response,
             response_description,
+            _Deadline(),
         )
 
 
@@ -2009,12 +2159,17 @@ def zoo_snapshot(
     highlighted via highlight_set_entities stand out instead of competing with
     the outline drawn on every edge in the scene.
     """
+    # One budget for the whole capture. A per-command budget would multiply by
+    # the command count, which for a four-view capture is fourteen commands.
+    deadline = _Deadline()
+
     with _modeling_websocket(session_id) as ws:
         _send_modeling_command(
             ws,
             ModelingCmd(OptionDefaultCameraSetOrthographic()),
             ResponseDefaultCameraSetOrthographic,
             "orthographic camera",
+            deadline,
         )
 
         # Scene-wide, so it is set once rather than per view.
@@ -2023,6 +2178,7 @@ def zoo_snapshot(
             ModelingCmd(OptionEdgeLinesVisible(hidden=not highlight_edges)),
             ResponseEdgeLinesVisible,
             "edge line visibility",
+            deadline,
         )
 
         zoom_to_fit = OptionZoomToFit(object_ids=[], padding=padding)
@@ -2035,6 +2191,7 @@ def zoo_snapshot(
                     ModelingCmd(view),
                     ResponseDefaultCameraLookAt,
                     "camera view",
+                    deadline,
                 )
             elif zoom:
                 _send_modeling_command(
@@ -2042,6 +2199,7 @@ def zoo_snapshot(
                     ModelingCmd(OptionViewIsometric()),
                     ResponseViewIsometric,
                     "isometric view",
+                    deadline,
                 )
 
             if zoom:
@@ -2050,6 +2208,7 @@ def zoo_snapshot(
                     ModelingCmd(zoom_to_fit),
                     ResponseZoomToFit,
                     "zoom to fit",
+                    deadline,
                 )
 
             response = _send_modeling_command(
@@ -2057,6 +2216,7 @@ def zoo_snapshot(
                 ModelingCmd(OptionTakeSnapshot(format=ImageFormat.JPEG)),
                 ResponseTakeSnapshot,
                 "snapshot",
+                deadline,
             )
             jpeg_contents_list.append(response.data.contents)
 

--- a/tests/test_modeling_commands.py
+++ b/tests/test_modeling_commands.py
@@ -53,6 +53,40 @@ def _clear_modeling_sessions():
     zoo_tools.zoo_stop_all_modeling_sessions()
 
 
+class _FakeClock:
+    """A monotonic clock the tests advance by hand.
+
+    Lets a 300s budget be exercised without a 300s test, and makes the
+    frame-by-frame accounting exact rather than timing-dependent.
+    """
+
+    def __init__(self, now: float = 1_000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _session_frame() -> SimpleNamespace:
+    """An unsolicited frame of the kind a live session interleaves."""
+    return SimpleNamespace(
+        root=SuccessWebSocketResponse(
+            request_id=None,
+            resp=OkWebSocketResponseData(
+                OptionModelingSessionData(
+                    data=ModelingSessionDataData(
+                        session=ModelingSessionData(api_call_id="api-call-id")
+                    )
+                )
+            ),
+            success=True,
+        )
+    )
+
+
 def _ok_frame(request_id: object, response: object) -> SimpleNamespace:
     return SimpleNamespace(
         root=SuccessWebSocketResponse(
@@ -521,11 +555,21 @@ async def test_execute_kcl_session_message_states_diagnostics_are_unavailable(
     assert "not" in result.message
 
 
-def test_exec_kcl_project_reads_with_a_timeout(monkeypatch: pytest.MonkeyPatch):
-    """Reading the raw socket without a timeout would hang forever."""
+def test_exec_kcl_project_reads_within_the_remaining_budget(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Each read is bounded by what is left of the call, not a fixed per-read value.
+
+    A fixed per-read timeout cannot bound this loop: the frame skipped below
+    would restart it, which is what let a stalled engine hang the caller.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(zoo_tools, "monotonic", clock)
+    monkeypatch.setattr(zoo_tools, "MODELING_COMMAND_TIMEOUT", 100.0)
+
     websocket = MagicMock()
-    websocket._recv_timeout = 12.5
     sent: dict[str, object] = {}
+    timeouts: list[float | None] = []
 
     def send(payload: str) -> None:
         import json
@@ -537,7 +581,11 @@ def test_exec_kcl_project_reads_with_a_timeout(monkeypatch: pytest.MonkeyPatch):
     def recv(timeout: float | None = None) -> str:
         import json
 
-        assert timeout == 12.5
+        timeouts.append(timeout)
+        clock.advance(10.0)
+        if len(timeouts) == 1:
+            # A frame for someone else's request must consume the budget.
+            return json.dumps({"success": True, "request_id": "other"})
         return json.dumps(
             {
                 "success": True,
@@ -552,6 +600,8 @@ def test_exec_kcl_project_reads_with_a_timeout(monkeypatch: pytest.MonkeyPatch):
     websocket.ws.recv.side_effect = recv
 
     result = zoo_tools._exec_kcl_project(cast(Any, websocket), "main.kcl", [])
+
+    assert timeouts == [100.0, 90.0]
 
     try:
         assert result.suffix == ".json"
@@ -582,6 +632,7 @@ def _capture_snapshot_commands(
         command: ModelingCmd,
         expected_response: type,
         description: str,
+        deadline: object = None,
     ) -> object:
         commands.append(command)
         return responses[cast(Any, expected_response)]
@@ -627,6 +678,9 @@ def test_snapshot_hides_edge_lines_by_default(monkeypatch: pytest.MonkeyPatch):
     """Edge outlines otherwise compete with highlight_set_entities."""
     commands = _capture_snapshot_commands(monkeypatch)
     monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
+    monkeypatch.setattr(
+        zoo_tools, "create_image_collage", MagicMock(return_value=b"collage")
+    )
 
     zoo_tools.zoo_snapshot(session_id="session-id")
 
@@ -761,3 +815,271 @@ def test_snapshot_fits_the_whole_session(
 def test_face_info_uuid_type_is_accepted():
     """Guard the Uuid alias the tools pass through to the engine."""
     assert str(Uuid("face-id")) == "face-id"
+
+
+def test_unmatched_frames_consume_the_budget_instead_of_resetting_it(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The regression this whole deadline exists for.
+
+    A live modeling session heartbeats every ~10s. Each of those frames used to
+    start a fresh per-read timeout, so the 300s bound could never elapse and a
+    stalled import blocked its caller for as long as the connection lived.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(zoo_tools, "monotonic", clock)
+    monkeypatch.setattr(zoo_tools, "MODELING_COMMAND_TIMEOUT", 300.0)
+
+    websocket = MagicMock()
+    timeouts: list[float] = []
+
+    def recv() -> SimpleNamespace:
+        timeouts.append(websocket._recv_timeout)
+        clock.advance(10.0)
+        return _session_frame()
+
+    websocket.recv.side_effect = recv
+
+    with pytest.raises(zoo_tools.ZooMCPTimeoutError) as exc_info:
+        zoo_tools._send_modeling_command(
+            cast(Any, websocket),
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+        )
+
+    # Each read is offered only what is left, so the budget runs out.
+    assert timeouts[:3] == [300.0, 290.0, 280.0]
+    assert len(timeouts) == 30
+    message = str(exc_info.value)
+    assert "entity index" in message
+    assert "300s" in message
+    assert "waited 300.0s" in message
+
+
+def test_command_times_out_when_the_engine_never_answers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    clock = _FakeClock()
+    monkeypatch.setattr(zoo_tools, "monotonic", clock)
+    monkeypatch.setattr(zoo_tools, "MODELING_COMMAND_TIMEOUT", 300.0)
+
+    websocket = MagicMock()
+
+    def recv() -> SimpleNamespace:
+        clock.advance(300.0)
+        raise TimeoutError
+
+    websocket.recv.side_effect = recv
+
+    with pytest.raises(zoo_tools.ZooMCPTimeoutError, match="entity index"):
+        zoo_tools._send_modeling_command(
+            cast(Any, websocket),
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+        )
+
+    assert websocket._recv_timeout == 300.0
+
+
+def test_a_timeout_is_a_zoo_mcp_exception_subclass():
+    """Callers that only catch ZooMCPException must still see a timeout."""
+    assert issubclass(zoo_tools.ZooMCPTimeoutError, ZooMCPException)
+
+
+def test_timeout_closes_and_evicts_the_session(monkeypatch: pytest.MonkeyPatch):
+    """A session whose engine still owes a response cannot be handed back."""
+    clock = _FakeClock()
+    monkeypatch.setattr(zoo_tools, "monotonic", clock)
+    monkeypatch.setattr(zoo_tools, "MODELING_COMMAND_TIMEOUT", 300.0)
+
+    websocket = MagicMock()
+
+    def recv() -> SimpleNamespace:
+        clock.advance(300.0)
+        raise TimeoutError
+
+    websocket.recv.side_effect = recv
+    context = MagicMock()
+    context.__enter__.return_value = websocket
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+
+    with pytest.raises(zoo_tools.ZooMCPTimeoutError):
+        zoo_tools.zoo_execute_modeling_command(
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+            session_id,
+        )
+
+    context.__exit__.assert_called_once_with(None, None, None)
+    assert zoo_tools._modeling_session is None
+    with pytest.raises(ZooMCPException, match="Unknown modeling session"):
+        zoo_tools.zoo_execute_modeling_command(
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+            session_id,
+        )
+
+
+def test_connection_close_mid_command_reports_a_dead_session(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    websocket = MagicMock()
+    websocket.recv.side_effect = ConnectionClosedError(None, None)
+    context = MagicMock()
+    context.__enter__.return_value = websocket
+    monkeypatch.setattr(zoo_tools, "_modeling_websocket_context", lambda: context)
+
+    session_id = zoo_tools.zoo_start_modeling_session()
+
+    with pytest.raises(ZooMCPException, match="no longer connected") as exc_info:
+        zoo_tools.zoo_execute_modeling_command(
+            ModelingCmd(OptionEntityGetIndex(entity_id="entity-id")),
+            ResponseEntityGetIndex,
+            "entity index",
+            session_id,
+        )
+
+    # A dead socket is not a timeout, so it must not be reported as retryable.
+    assert not isinstance(exc_info.value, zoo_tools.ZooMCPTimeoutError)
+    assert zoo_tools._modeling_session is None
+
+
+def test_snapshot_shares_one_budget_across_all_its_commands(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Otherwise a four-view capture gets fourteen separate budgets."""
+    seen: list[object] = []
+
+    def send_command(
+        ws: object,
+        command: ModelingCmd,
+        expected_response: type,
+        description: str,
+        deadline: object = None,
+    ) -> object:
+        seen.append(deadline)
+        if expected_response is zoo_tools.ResponseTakeSnapshot:
+            return SimpleNamespace(data=TakeSnapshot(contents="anBlZw=="))
+        return SimpleNamespace(data=None)
+
+    monkeypatch.setattr(zoo_tools, "_send_modeling_command", send_command)
+    monkeypatch.setattr(
+        zoo_tools,
+        "_modeling_websocket",
+        lambda session_id: nullcontext(MagicMock()),
+    )
+    monkeypatch.setattr(zoo_tools, "resize_image", MagicMock(return_value=b"jpeg"))
+    monkeypatch.setattr(
+        zoo_tools, "create_image_collage", MagicMock(return_value=b"collage")
+    )
+
+    zoo_tools.zoo_snapshot(
+        session_id="session-id",
+        views=[_camera_view("front"), _camera_view("right")],
+    )
+
+    assert len(seen) > 1
+    assert all(isinstance(deadline, zoo_tools._Deadline) for deadline in seen)
+    assert len({id(deadline) for deadline in seen}) == 1
+
+
+def _stub_import_transport(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    websocket = MagicMock()
+    monkeypatch.setattr(
+        zoo_tools,
+        "_modeling_websocket",
+        lambda session_id: nullcontext(websocket),
+    )
+    return websocket
+
+
+def test_import_logs_safe_metadata_and_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+):
+    """Enough to correlate a stalled import server-side, and no file contents."""
+    step = tmp_path / "part.step"
+    step.write_text("ISO-10303-21; SECRET-CUSTOMER-GEOMETRY")
+    _stub_import_transport(monkeypatch)
+    monkeypatch.setattr(
+        zoo_tools,
+        "_await_modeling_response",
+        lambda *args, **kwargs: SimpleNamespace(
+            data=SimpleNamespace(object_id="object-id")
+        ),
+    )
+
+    with caplog.at_level("INFO", logger="zoo_mcp"):
+        assert zoo_tools.zoo_import_cad_file("session-id", step) == "object-id"
+
+    records = [r.getMessage() for r in caplog.records if "CAD import" in r.getMessage()]
+    assert len(records) == 2
+    sent, finished = records
+    assert "CAD import sent" in sent
+    assert "outcome=awaiting-engine-response" in sent
+    assert "CAD import finished" in finished
+    assert "outcome=imported" in finished
+    for record in records:
+        assert "session=session-id" in record
+        assert "ext=step" in record
+        assert f"bytes={step.stat().st_size}" in record
+        assert "request_id=" in record
+        assert "elapsed=" in record
+        assert "SECRET-CUSTOMER-GEOMETRY" not in record
+
+
+def test_import_timeout_is_logged_and_raised(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+):
+    step = tmp_path / "part.step"
+    step.write_bytes(b"ISO-10303-21;")
+    _stub_import_transport(monkeypatch)
+
+    def timeout(*args: object, **kwargs: object) -> None:
+        raise zoo_tools.ZooMCPTimeoutError("engine went quiet")
+
+    monkeypatch.setattr(zoo_tools, "_await_modeling_response", timeout)
+
+    with (
+        caplog.at_level("INFO", logger="zoo_mcp"),
+        pytest.raises(zoo_tools.ZooMCPTimeoutError),
+    ):
+        zoo_tools.zoo_import_cad_file("session-id", step)
+
+    assert any(
+        "CAD import finished" in r.getMessage() and "outcome=timeout" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_import_waits_within_one_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """The import's own read loop is the one the production hang sat in."""
+    clock = _FakeClock()
+    monkeypatch.setattr(zoo_tools, "monotonic", clock)
+    monkeypatch.setattr(zoo_tools, "MODELING_COMMAND_TIMEOUT", 120.0)
+
+    step = tmp_path / "part.step"
+    step.write_bytes(b"ISO-10303-21;")
+    websocket = _stub_import_transport(monkeypatch)
+
+    def recv() -> SimpleNamespace:
+        clock.advance(10.0)
+        return _session_frame()
+
+    websocket.recv.side_effect = recv
+
+    with pytest.raises(zoo_tools.ZooMCPTimeoutError, match="CAD file import"):
+        zoo_tools.zoo_import_cad_file("session-id", step)
+
+    assert websocket.recv.call_count == 12

--- a/tests/test_server_modeling_commands.py
+++ b/tests/test_server_modeling_commands.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 from types import SimpleNamespace
@@ -656,3 +658,72 @@ async def test_query_tools_document_their_arguments():
         description = tools[tool_name].description or ""
         assert "Args:" in description, tool_name
         assert "session_id:" in description, tool_name
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_modeling_call_does_not_starve_other_tools(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """MCP runs every tool handler on one event loop.
+
+    Calling a synchronous modeling read inline used to block that loop, so one
+    stalled import froze the whole server and left no path for the client's
+    cancellation to arrive. The read has to happen on a worker thread.
+    """
+    release = threading.Event()
+    entered = threading.Event()
+
+    def blocking_import(session_id: str, input_file: str) -> str:
+        entered.set()
+        assert release.wait(timeout=5), "import was never released"
+        return "object-id"
+
+    monkeypatch.setattr(server, "zoo_import_cad_file", blocking_import)
+    monkeypatch.setattr(server, "zoo_get_modeling_sessions", lambda: ["session-id"])
+
+    stalled = asyncio.create_task(
+        mcp.call_tool(
+            "import_cad_file",
+            arguments={"session_id": "session-id", "input_file": "part.step"},
+        )
+    )
+    await asyncio.to_thread(entered.wait, 5)
+
+    # The loop is still live, so an unrelated tool completes while the import hangs.
+    other = await mcp.call_tool("get_modeling_sessions", arguments={})
+    assert _result(other) == ["session-id"]
+
+    # And the stalled call is a real task, so it is cancellable from the loop.
+    assert not stalled.done()
+    release.set()
+    assert _result(await stalled) == "object-id"
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_modeling_call_can_be_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    release = threading.Event()
+    entered = threading.Event()
+
+    def blocking_import(session_id: str, input_file: str) -> str:
+        entered.set()
+        release.wait(timeout=5)
+        return "object-id"
+
+    monkeypatch.setattr(server, "zoo_import_cad_file", blocking_import)
+
+    stalled = asyncio.create_task(
+        mcp.call_tool(
+            "import_cad_file",
+            arguments={"session_id": "session-id", "input_file": "part.step"},
+        )
+    )
+    await asyncio.to_thread(entered.wait, 5)
+    stalled.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await stalled
+
+    # The worker thread still finishes on its own; its own deadline bounds it.
+    release.set()

--- a/uv.lock
+++ b/uv.lock
@@ -1141,7 +1141,7 @@ wheels = [
 
 [[package]]
 name = "zoo-mcp"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Bounds how long a modeling tool call can wait on the engine.

`_await_modeling_response` read the modeling websocket in a `while True` loop, and the SDK applies its receive timeout per `recv()` rather than per command. A live session emits an unsolicited `metrics_request` frame every ~10s, so each skipped frame restarted the 300s timeout and it could never elapse — a CAD import that stalled server-side blocked its caller for as long as the connection stayed up.

- Every modeling tool call now carries a monotonic `_Deadline` (`MODELING_COMMAND_TIMEOUT`, 300s) shared by all of its reads, so skipped frames consume the budget instead of resetting it. Threaded through `_await_modeling_response`, `zoo_face_info`, and the raw `_exec_kcl_project` loop; `zoo_snapshot` shares one budget across every command it sends.
- Expiry raises `ZooMCPTimeoutError` and closes and evicts the session. It subclasses `ZooMCPException` so existing handlers still catch it, while letting callers tell a stalled engine from a rejected command.
- The MCP tools hand these synchronous reads to `asyncio.to_thread`. MCP dispatches every handler onto one event loop, so a blocked read previously stalled the whole server rather than just its own call.
- `import_cad_file` logs the session ID, request ID, extension, byte size, elapsed time, and terminal outcome at each stage.

Fixes #232
